### PR TITLE
refactor: add TUGL to gas killer gas estimate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use gk::GasKillerDefault;
 use sol_types::{IStateUpdateTypes, StateUpdate, StateUpdateType, StateUpdates};
 use url::Url;
 
-const TURETZKY_UPPER_GAS_LIMIT: u64 = 200000u64;
+const TURETZKY_UPPER_GAS_LIMIT: u64 = 250000u64;
 
 fn copy_memory(memory: &[u8], offset: usize, length: usize) -> Vec<u8> {
     if memory.len() >= offset + length {
@@ -368,6 +368,7 @@ pub async fn gaskiller_reporter(
             &state_updates,
         )
         .await?;
+    let gaskiller_gas_estimate = gaskiller_gas_estimate + TURETZKY_UPPER_GAS_LIMIT;
     let gas_used = receipt.gas_used;
     let approx_gas_price_per_unit: f64 = receipt.effective_gas_price as f64 / gas_used as f64;
     let gaskiller_estimated_gas_cost = approx_gas_price_per_unit * gaskiller_gas_estimate as f64;


### PR DESCRIPTION
#65 

I manually tested this against a railgun tx: https://etherscan.io/tx/0xaaca62e3b89841d23604aac913f98c36167cd77c9915754742250f2639228719

before PR - 76.2% savings estimate:
```python
['2025-07-29T10:05:21.325004925Z', 'a2ac639', '0xaaca62e3b89841d23604aac913f98c36167cd77c9915754742250f2639228719', '0xb2eaf46c9c5658c40c05505da3b19e7e0337920e079d325616b14c47d40c0297', '23024077', '1119327', '416852559', '372.4135654728243', '265524', '98884739.5586062', '853803', '76.27824576732269', '0xd8ae136a', '', '']
```

after PR - 53.9% savings estimate:
```csv
2025-09-20T11:47:03.980535201Z,c0b0ead,0xaaca62e3b89841d23604aac913f98c36167cd77c9915754742250f2639228719,0xb2eaf46c9c5658c40c05505da3b19e7e0337920e079d325616b14c47d40c0297,23024077,1119327,416852559,372.4135654728243,515524,191988130.92681226,603803,53.94339634441052,0xd8ae136a,,
```