### PR TITLE
feat: encode state updates as (StateUpdateType[], bytes[]) tuple

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,9 +932,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_encoding_format() -> Result<()> {
-        // Test that encoding produces the correct format for Solidity consumption
-        // The bug was that StateUpdates::abi_encode wraps in an extra tuple layer
-
         // Create multiple state updates to match the chisel example
         let state_updates = vec![
             StateUpdate::Store(IStateUpdateTypes::Store {


### PR DESCRIPTION
## Summary

Changed encoding from raw parameter list to proper ABI tuple encoding for `(StateUpdateType[], bytes[])`.

- Encodes StateUpdateType enum array with each enum value as a full 32-byte word (per Solidity ABI spec)
- Properly encodes bytes[] array with dynamic offsets and payloads
- Returns tuple that can be decoded in Solidity as:
  ```solidity
  (StateUpdateType[] memory types, bytes[] memory args) = abi.decode(storageUpdates, (StateUpdateType[], bytes[]));
  ```

## Changes

1. **Tuple encoding**: Encodes as `(types[], data[])` with proper offsets instead of raw parameter list
2. **Enum encoding**: Each StateUpdateType value encoded as full 32-byte word (not packed bytes)
3. **Logging**: Added detailed logging showing offset structure and expected decode format
4. **Test**: Added `test_stateupdatetype_tuple_encoding()` with full hex output for verification

## Test Output

Encoded 3 state updates (STORE, LOG0, LOG1):
- Length: 704 bytes
- Format: (StateUpdateType[], bytes[])
- Offsets: 0x40 (types), 0xc0 (bytes[])