### PR TITLE
Fix Cow<str> compatibility for StructLog.op field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,16 +59,16 @@ fn append_to_state_updates(
     stack.reverse();
     let memory = match struct_log.memory {
         Some(memory) => parse_trace_memory(memory),
-        None => match struct_log.op.as_str() {
+        None => match struct_log.op.as_ref() {
             "CALL" | "LOG0" | "LOG1" | "LOG2" | "LOG3" | "LOG4" if struct_log.depth == 1 => {
                 bail!("There is no memory for {:?} in depth 1", struct_log.op)
             }
             _ => return Ok(None),
         },
     };
-    match struct_log.op.as_str() {
+    match struct_log.op.as_ref() {
         "CREATE" | "CREATE2" | "SELFDESTRUCT" => {
-            return Ok(Some(struct_log.op));
+            return Ok(Some(struct_log.op.to_string()));
         }
         "DELEGATECALL" | "CALLCODE" => {
             bail!(
@@ -159,7 +159,7 @@ pub async fn compute_state_updates(
         } else if struct_log.depth == target_depth {
             // If we're going to step into a new execution context, increase the target depth
             // else, try to add the state update
-            if struct_log.op.as_str() == "DELEGATECALL" || struct_log.op.as_str() == "CALLCODE" {
+            if &*struct_log.op == "DELEGATECALL" || &*struct_log.op == "CALLCODE" {
                 target_depth = struct_log.depth + 1;
             } else if let Some(opcode) = append_to_state_updates(&mut state_updates, struct_log)? {
                 skipped_opcodes.insert(opcode);


### PR DESCRIPTION
## Summary
Updates StructLog.op field handling to work with Cow<'_, str> instead of String, eliminating dependency on the unstable str_as_str feature.

## Changes
- Lines 62, 69: Changed `.as_str()` to `.as_ref()` in match expressions
- Line 71: Added `.to_string()` to convert Cow<str> to Opcode (String)
- Line 162: Use `&*` dereference for string comparison