### PR TITLE
fix: patch svm-rs to fix duplicate solc 0.8.31 build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5965,9 +5965,8 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f15cc0fb280301739995e3b9f0f0dde3aecb876814f4768689f9138570cd3b"
+version = "0.5.21"
+source = "git+https://github.com/alloy-rs/svm-rs?rev=ee99800a8a1b803263fcc12fe3ed8c059e2302c4#ee99800a8a1b803263fcc12fe3ed8c059e2302c4"
 dependencies = [
  "const-hex",
  "dirs",
@@ -5984,9 +5983,8 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31affc47068aeef445accc5c3d5f7fd24f9072cae0a651cef564239003c94ff8"
+version = "0.5.21"
+source = "git+https://github.com/alloy-rs/svm-rs?rev=ee99800a8a1b803263fcc12fe3ed8c059e2302c4#ee99800a8a1b803263fcc12fe3ed8c059e2302c4"
 dependencies = [
  "const-hex",
  "semver 1.0.26",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ serde_json = "1.0"
 [[example]]
 name = "tx_extractor_example"
 path = "examples/tx_extractor_example.rs"
+
+[patch.crates-io]
+svm-rs-builds = { git = "https://github.com/alloy-rs/svm-rs", rev = "ee99800a8a1b803263fcc12fe3ed8c059e2302c4" }
+svm-rs = { git = "https://github.com/alloy-rs/svm-rs", rev = "ee99800a8a1b803263fcc12fe3ed8c059e2302c4" }


### PR DESCRIPTION
## Summary
- Patches `svm-rs` and `svm-rs-builds` to use the fix from upstream PR [alloy-rs/svm-rs#178](https://github.com/alloy-rs/svm-rs/pull/178) which ignores prereleases in svm-builds
- Fixes build failure caused by duplicate `SOLC_VERSION_0_8_31` constant definitions

## Context
Upstream `svm-rs-builds` has a bug where solc version 0.8.31 appears twice in the solidity binaries list (once as prerelease, once as stable release), causing duplicate constant definitions and E0428 compilation errors.

Related: https://github.com/alloy-rs/svm-rs/issues/177

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes
- [x] `cargo fmt --all -- --check` passes

## Notes
This is a temporary fix until the upstream PR is merged and released. Once `svm-rs-builds` >= 0.5.22 (or whichever version includes the fix) is released, we can remove the `[patch.crates-io]` section.