### PR TITLE
Fix decode_state_updates_tuple offset bug and improve test assertions

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -673,7 +673,10 @@ pub struct StateUpdateReport {
 mod tests {
     use super::*;
     use gas_analyzer_core::constants::*;
-    use gas_analyzer_core::{IStateUpdateTypes, StateUpdateType, decode_state_updates_tuple};
+    use gas_analyzer_core::{
+        IStateUpdateTypes, StateUpdateType, decode_state_updates_tuple,
+        encode_state_updates_to_sol,
+    };
 
     // Local sol! with #[sol(rpc)] for test that needs SimpleStorageInstance
     alloy::sol! {
@@ -709,7 +712,14 @@ mod tests {
             types,
             vec![U256::from(0u8), U256::from(2u8), U256::from(3u8),]
         );
-        assert_eq!(data.len(), 3);
+        let (_, expected_data) = encode_state_updates_to_sol(&state_updates);
+        assert_eq!(data.len(), expected_data.len());
+        for (i, (decoded, expected)) in data.iter().zip(expected_data.iter()).enumerate() {
+            assert_eq!(
+                decoded, expected,
+                "data[{i}] mismatch: decoded bytes don't match encoded input"
+            );
+        }
         Ok(())
     }
 
@@ -738,6 +748,15 @@ mod tests {
         assert_eq!(types[0], U256::from(StateUpdateType::STORE as u8));
         assert_eq!(types[1], U256::from(StateUpdateType::LOG0 as u8));
         assert_eq!(types[2], U256::from(StateUpdateType::LOG1 as u8));
+
+        // Verify decoded data matches the original ABI-encoded state updates
+        let (_, expected_data) = encode_state_updates_to_sol(&state_updates);
+        for (i, (decoded, expected)) in data.iter().zip(expected_data.iter()).enumerate() {
+            assert_eq!(
+                decoded, expected,
+                "data[{i}] mismatch: decoded bytes don't match encoded input"
+            );
+        }
 
         // Verify the encoding doesn't start with 0x20 (the extra wrapper)
         // The first 32 bytes should be 0x40 (offset to types[]), not 0x20

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -673,10 +673,7 @@ pub struct StateUpdateReport {
 mod tests {
     use super::*;
     use gas_analyzer_core::constants::*;
-    use gas_analyzer_core::{
-        IStateUpdateTypes, StateUpdateType, decode_state_updates_tuple,
-        encode_state_updates_to_sol,
-    };
+    use gas_analyzer_core::{IStateUpdateTypes, StateUpdateType, encode_state_updates_to_sol};
 
     // Local sol! with #[sol(rpc)] for test that needs SimpleStorageInstance
     alloy::sol! {
@@ -686,8 +683,50 @@ mod tests {
         }
     }
     use alloy::primitives::{U256, address, b256, bytes};
+    use anyhow::bail;
     use csv::Writer;
     use std::fs::File;
+
+    /// Decode (uint256[], bytes[]) ABI tuple used for state update transport
+    fn decode_state_updates_tuple(data: &[u8]) -> Result<(Vec<U256>, Vec<Bytes>)> {
+        fn read_u256_as_usize(word: &[u8]) -> usize {
+            let mut buf = [0u8; 16];
+            let copy_len = word.len().min(16);
+            buf[16 - copy_len..].copy_from_slice(&word[word.len() - copy_len..]);
+            u128::from_be_bytes(buf) as usize
+        }
+
+        fn get(data: &[u8], start: usize, len: usize) -> Result<&[u8]> {
+            if start + len > data.len() {
+                bail!("slice {}..{} of {}", start, start + len, data.len());
+            }
+            Ok(&data[start..start + len])
+        }
+
+        let types_offset = read_u256_as_usize(get(data, 0, 32)?);
+        let data_offset = read_u256_as_usize(get(data, 32, 32)?);
+
+        // types: uint256[]
+        let n_types = read_u256_as_usize(get(data, types_offset, 32)?);
+        let mut types = Vec::with_capacity(n_types);
+        for i in 0..n_types {
+            let word = get(data, types_offset + 32 + i * 32, 32)?;
+            types.push(U256::from_be_slice(word));
+        }
+
+        // data: bytes[]
+        let n_data = read_u256_as_usize(get(data, data_offset, 32)?);
+        let head = data_offset + 32;
+        let mut out = Vec::with_capacity(n_data);
+        for i in 0..n_data {
+            let rel = read_u256_as_usize(get(data, head + i * 32, 32)?);
+            let start = head + rel;
+            let len = read_u256_as_usize(get(data, start, 32)?);
+            out.push(Bytes::copy_from_slice(get(data, start + 32, len)?));
+        }
+
+        Ok((types, out))
+    }
 
     #[test]
     fn test_stateupdatetype_tuple_encoding() -> Result<()> {

--- a/crates/core/src/encoding.rs
+++ b/crates/core/src/encoding.rs
@@ -3,9 +3,8 @@
 //! This module provides functions for ABI-encoding state updates
 //! for transport to the StateChangeHandler contract.
 
-use alloy_primitives::{Bytes, U256};
+use alloy_primitives::Bytes;
 use alloy_sol_types::SolValue;
-use anyhow::{Result, bail};
 
 use crate::types::{StateUpdate, StateUpdateType};
 
@@ -119,47 +118,4 @@ pub fn encode_state_updates_to_abi(state_updates: &[StateUpdate]) -> Bytes {
     encoded.extend_from_slice(&datas_payload);
 
     Bytes::copy_from_slice(&encoded)
-}
-
-/// Decode (uint256[], bytes[]) ABI tuple used for state update transport
-#[allow(dead_code)]
-pub fn decode_state_updates_tuple(data: &[u8]) -> Result<(Vec<U256>, Vec<Bytes>)> {
-    fn read_u256_as_usize(word: &[u8]) -> usize {
-        let mut buf = [0u8; 16];
-        let copy_len = word.len().min(16);
-        buf[16 - copy_len..].copy_from_slice(&word[word.len() - copy_len..]);
-        u128::from_be_bytes(buf) as usize
-    }
-
-    fn get(data: &[u8], start: usize, len: usize) -> Result<&[u8]> {
-        if start + len > data.len() {
-            bail!("slice {}..{} of {}", start, start + len, data.len());
-        }
-        Ok(&data[start..start + len])
-    }
-
-    let types_offset = read_u256_as_usize(get(data, 0, 32)?);
-    let data_offset = read_u256_as_usize(get(data, 32, 32)?);
-
-    // types: uint256[]
-    let n_types = read_u256_as_usize(get(data, types_offset, 32)?);
-    let mut types = Vec::with_capacity(n_types);
-    for i in 0..n_types {
-        let word = get(data, types_offset + 32 + i * 32, 32)?;
-        types.push(U256::from_be_slice(word));
-    }
-
-    // data: bytes[]
-    let n_data = read_u256_as_usize(get(data, data_offset, 32)?);
-    let head = data_offset + 32;
-    let tail = head + 32 * n_data;
-    let mut out = Vec::with_capacity(n_data);
-    for i in 0..n_data {
-        let rel = read_u256_as_usize(get(data, head + i * 32, 32)?);
-        let start = tail + rel;
-        let len = read_u256_as_usize(get(data, start, 32)?);
-        out.push(Bytes::copy_from_slice(get(data, start + 32, len)?));
-    }
-
-    Ok((types, out))
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,8 +12,7 @@ pub mod types;
 
 // Re-export commonly used items
 pub use encoding::{
-    TURETZKY_UPPER_GAS_LIMIT, decode_state_updates_tuple, encode_state_updates_to_abi,
-    encode_state_updates_to_sol,
+    TURETZKY_UPPER_GAS_LIMIT, encode_state_updates_to_abi, encode_state_updates_to_sol,
 };
 pub use heuristic::{
     BASE_TX_COST, LOG_BASE_COST, LOG_DATA_COST_PER_BYTE, LOG_TOPIC_COST, TraceOperations,


### PR DESCRIPTION
## Summary
- Fix critical offset calculation bug in `decode_state_updates_tuple`: offsets are relative to `head`, not `tail` (`head + rel` instead of `tail + rel`)
- Add full round-trip assertions to `test_stateupdatetype_tuple_encoding` and `test_encoding_format` — decoded bytes are now compared against expected ABI-encoded values from `encode_state_updates_to_sol`
- Move `decode_state_updates_tuple` from `core/encoding.rs` into the anvil test module where it's actually used, removing the misleading `#[allow(dead_code)]`

Closes #73

## Test plan
- [x] `cargo test -p gas-analyzer-anvil -- test_stateupdatetype_tuple_encoding test_encoding_format` — both pass
- [x] `cargo check` — clean build, no warnings
