### PR TITLE
feat: add --verbose CLI mode for ABI decoding + traced rerun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,10 @@ name = "gas-analyzer-cli"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "alloy-dyn-abi",
  "alloy-eips",
+ "alloy-json-abi",
+ "alloy-primitives",
  "alloy-provider",
  "anyhow",
  "colored",
@@ -3273,6 +3276,8 @@ dependencies = [
  "gas-analyzer-evmsketch",
  "gas-analyzer-rpc",
  "hex",
+ "reqwest",
+ "serde_json",
  "tokio",
  "url",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,12 +11,17 @@ path = "src/main.rs"
 gas-analyzer-core = { path = "../core" }
 gas-analyzer-rpc = { path = "../rpc" }
 alloy = { version = "1.0.37", features = ["rpc", "rpc-types"] }
+alloy-dyn-abi = "1.0.37"
 alloy-eips = "1.0.37"
+alloy-json-abi = "1.0.37"
+alloy-primitives = "1.0.37"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 colored = "3.0.0"
 dotenv = "0.15.0"
 hex = "0.4"
+reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1.0"
 tokio = { version = "1.45.1", features = ["rt-multi-thread"] }
 url = "2.5.4"
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,9 @@ use gas_analyzer_core::RevertingContext;
 use std::env;
 use url::Url;
 
+mod verbose;
+use verbose::Verbose;
+
 /// Try to decode a `RevertingContext` error from an anyhow error.
 ///
 /// Looks for hex-encoded revert data in the error message (the format revm
@@ -35,6 +38,7 @@ struct CliArgs {
     command: Option<Commands>,
     use_anvil: bool,
     debug: bool,
+    verbose: bool,
 }
 
 fn parse_args() -> CliArgs {
@@ -46,11 +50,14 @@ fn parse_args() -> CliArgs {
     // Check for --debug flag
     let debug = args.iter().any(|a| a == "--debug");
 
+    // Check for --verbose / -v flag
+    let verbose = args.iter().any(|a| a == "--verbose" || a == "-v");
+
     // Filter out flags to get positional args
     let positional: Vec<&str> = args
         .iter()
         .map(|s| s.as_str())
-        .filter(|a| !a.starts_with("--"))
+        .filter(|a| !a.starts_with('-'))
         .collect();
 
     let command = if positional.len() < 3 {
@@ -77,6 +84,7 @@ fn parse_args() -> CliArgs {
         command,
         use_anvil,
         debug,
+        verbose,
     }
 }
 
@@ -205,6 +213,8 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
             {
                 println!("Using EvmSketch implementation...");
 
+                let verbose = Verbose::new(cli_args.verbose);
+
                 // Use shared trace function from rpc crate
                 use gas_analyzer_rpc::compute_state_updates_from_tx;
 
@@ -323,6 +333,9 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                         );
                     }
 
+                    // Verbose: decode every state update against Etherscan ABIs.
+                    verbose.print_state_updates(&state_updates).await;
+
                     // Try measured gas estimation with preceding tx replay
                     match gk.estimate_state_changes_gas_with_preceding(
                         contract_address,
@@ -357,6 +370,13 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                                             hex::encode(&ctx.callargs)
                                         );
                                     }
+                                    verbose.print_reverting_context(&ctx).await;
+                                    verbose.rerun_with_tracing(
+                                        &gk,
+                                        contract_address,
+                                        tx_sender,
+                                        &state_updates,
+                                    );
                                 }
                                 None => {
                                     if cli_args.debug {
@@ -463,6 +483,14 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
             println!(
                 "  {} Print full error details including RPC errors",
                 "--debug".bold()
+            );
+            println!(
+                "  {} ABI-decode state updates and trace failed estimations",
+                "-v / --verbose".bold()
+            );
+            println!(
+                "    (requires {} environment variable)",
+                "ETHERSCAN_API_KEY".bold()
             );
             println!("\nExamples:\n");
             println!("  # Default (EvmSketch - Anvil-free):");

--- a/crates/cli/src/verbose/decode.rs
+++ b/crates/cli/src/verbose/decode.rs
@@ -1,0 +1,121 @@
+//! Pure ABI decode helpers used by the verbose printers.
+//!
+//! These are split from [`super::etherscan`] (which only owns the HTTP cache)
+//! and from [`super::print`] (which owns the formatting) so they can be
+//! tested in isolation and so the verbose entry-points read as a thin layer
+//! over `decode_*` calls.
+
+use alloy_dyn_abi::{DynSolType, DynSolValue, JsonAbiExt};
+use alloy_json_abi::JsonAbi;
+use alloy_primitives::Bytes;
+
+/// Render a [`DynSolValue`] as a short string suitable for one-line printing.
+/// Long byte arrays are truncated with a `…(len=N)` marker.
+pub fn render_value(v: &DynSolValue) -> String {
+    match v {
+        DynSolValue::Address(a) => format!("0x{:x}", a),
+        DynSolValue::Bool(b) => b.to_string(),
+        DynSolValue::Int(i, _) => i.to_string(),
+        DynSolValue::Uint(u, _) => u.to_string(),
+        DynSolValue::FixedBytes(b, n) => format!("0x{}", hex::encode(&b.0[..*n])),
+        DynSolValue::Bytes(b) => {
+            if b.len() > 80 {
+                format!("0x{}…(len={})", hex::encode(&b[..40]), b.len())
+            } else {
+                format!("0x{}", hex::encode(b))
+            }
+        }
+        DynSolValue::String(s) => format!("{s:?}"),
+        DynSolValue::Array(arr) | DynSolValue::FixedArray(arr) => {
+            let inner: Vec<_> = arr.iter().map(render_value).collect();
+            format!("[{}]", inner.join(", "))
+        }
+        DynSolValue::Tuple(t) => {
+            let inner: Vec<_> = t.iter().map(render_value).collect();
+            format!("({})", inner.join(", "))
+        }
+        _ => format!("{:?}", v),
+    }
+}
+
+/// Decoded view of a successful function-call match against an ABI.
+pub struct DecodedCall {
+    pub name: String,
+    pub signature: String,
+    /// `(typed_name, rendered_value)` for each input parameter.
+    pub args: Vec<(String, String)>,
+}
+
+/// Decode `calldata` against `abi`, looking for a function whose 4-byte
+/// selector matches and whose input schema decodes the rest of the data.
+/// Returns `None` if no function matches.
+pub fn decode_call(abi: &JsonAbi, calldata: &Bytes) -> Option<DecodedCall> {
+    if calldata.len() < 4 {
+        return None;
+    }
+    let selector: [u8; 4] = calldata[..4].try_into().ok()?;
+    let body = &calldata[4..];
+
+    for func in abi.functions() {
+        if func.selector().0 != selector {
+            continue;
+        }
+        let Ok(decoded) = func.abi_decode_input(body) else {
+            continue;
+        };
+        let args: Vec<(String, String)> = func
+            .inputs
+            .iter()
+            .zip(decoded.iter())
+            .map(|(p, v)| {
+                let name = if p.name.is_empty() {
+                    p.ty.clone()
+                } else {
+                    format!("{} {}", p.ty, p.name)
+                };
+                (name, render_value(v))
+            })
+            .collect();
+        return Some(DecodedCall {
+            name: func.name.clone(),
+            signature: func.signature(),
+            args,
+        });
+    }
+    None
+}
+
+/// Decode revert `data` into a human-readable string. Handles the standard
+/// `Error(string)` and `Panic(uint256)` selectors, and any custom error
+/// declared in `abi` (when provided).
+pub fn decode_revert(abi: Option<&JsonAbi>, data: &[u8]) -> Option<String> {
+    if data.len() < 4 {
+        return None;
+    }
+
+    if data[..4] == [0x08, 0xc3, 0x79, 0xa0]
+        && let Ok(DynSolValue::String(s)) = DynSolType::String.abi_decode(&data[4..])
+    {
+        return Some(format!("Error({s:?})"));
+    }
+
+    if data[..4] == [0x4e, 0x48, 0x7b, 0x71]
+        && let Ok(DynSolValue::Uint(code, _)) = DynSolType::Uint(256).abi_decode(&data[4..])
+    {
+        return Some(format!("Panic(0x{:x})", code));
+    }
+
+    if let Some(abi) = abi {
+        let selector: [u8; 4] = data[..4].try_into().ok()?;
+        for err in abi.errors() {
+            if err.selector().0 == selector
+                && let Ok(decoded) = err.abi_decode_input(&data[4..])
+            {
+                let inner: Vec<String> = decoded.iter().map(render_value).collect();
+                return Some(format!("{}({})", err.name, inner.join(", ")));
+            }
+        }
+    }
+
+    None
+}

--- a/crates/cli/src/verbose/etherscan.rs
+++ b/crates/cli/src/verbose/etherscan.rs
@@ -65,10 +65,7 @@ impl EtherscanClient {
 
     /// Calls `getsourcecode` and returns `(abi, implementation_address)`.
     /// `implementation_address` is `Some` for verified proxies.
-    async fn fetch_source(
-        &self,
-        address: Address,
-    ) -> Result<(Option<JsonAbi>, Option<Address>)> {
+    async fn fetch_source(&self, address: Address) -> Result<(Option<JsonAbi>, Option<Address>)> {
         let url = format!(
             "{ETHERSCAN_V2}?chainid={}&module=contract&action=getsourcecode&address=0x{:x}&apikey={}",
             self.chain_id, address, self.api_key
@@ -95,8 +92,7 @@ impl EtherscanClient {
             .ok_or_else(|| anyhow!("etherscan getsourcecode missing result[0]"))?;
 
         let abi_str = entry.get("ABI").and_then(|v| v.as_str()).unwrap_or("");
-        let abi = if abi_str.is_empty()
-            || abi_str.starts_with("Contract source code not verified")
+        let abi = if abi_str.is_empty() || abi_str.starts_with("Contract source code not verified")
         {
             None
         } else {

--- a/crates/cli/src/verbose/etherscan.rs
+++ b/crates/cli/src/verbose/etherscan.rs
@@ -1,0 +1,121 @@
+//! Etherscan v2 ABI fetcher with proxy resolution.
+//!
+//! Fetches verified ABIs by address, transparently merging in the
+//! implementation contract's ABI when the address is a verified proxy.
+//! Caches per-address (including misses) so a single CLI run hits the API
+//! at most once per address.
+
+use alloy_json_abi::JsonAbi;
+use alloy_primitives::Address;
+use anyhow::{Context, Result, anyhow};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+const ETHERSCAN_V2: &str = "https://api.etherscan.io/v2/api";
+
+/// Etherscan v2 client. Construct with [`EtherscanClient::new`] and call
+/// [`fetch_abi`](Self::fetch_abi).
+pub struct EtherscanClient {
+    api_key: String,
+    chain_id: u64,
+    http: reqwest::Client,
+    cache: Mutex<HashMap<Address, Option<JsonAbi>>>,
+}
+
+impl EtherscanClient {
+    pub fn new(api_key: String, chain_id: u64) -> Self {
+        Self {
+            api_key,
+            chain_id,
+            http: reqwest::Client::new(),
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Returns the ABI for `address`. If the address is a verified proxy with
+    /// a known implementation, the implementation's ABI is merged in so that
+    /// proxied selectors are decodable. Returns `None` if the address itself
+    /// is not verified on Etherscan.
+    pub async fn fetch_abi(&self, address: Address) -> Result<Option<JsonAbi>> {
+        if let Some(cached) = self.cache.lock().unwrap().get(&address).cloned() {
+            return Ok(cached);
+        }
+
+        let (mut abi, impl_addr) = self.fetch_source(address).await?;
+
+        if let Some(impl_addr) = impl_addr
+            && impl_addr != Address::ZERO
+            && impl_addr != address
+        {
+            let (impl_abi, _) = self.fetch_source(impl_addr).await?;
+            match (abi.as_mut(), impl_abi) {
+                (Some(base), Some(extra)) => {
+                    base.functions.extend(extra.functions);
+                    base.errors.extend(extra.errors);
+                    base.events.extend(extra.events);
+                }
+                (None, Some(extra)) => abi = Some(extra),
+                _ => {}
+            }
+        }
+
+        self.cache.lock().unwrap().insert(address, abi.clone());
+        Ok(abi)
+    }
+
+    /// Calls `getsourcecode` and returns `(abi, implementation_address)`.
+    /// `implementation_address` is `Some` for verified proxies.
+    async fn fetch_source(
+        &self,
+        address: Address,
+    ) -> Result<(Option<JsonAbi>, Option<Address>)> {
+        let url = format!(
+            "{ETHERSCAN_V2}?chainid={}&module=contract&action=getsourcecode&address=0x{:x}&apikey={}",
+            self.chain_id, address, self.api_key
+        );
+        let resp: serde_json::Value = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("etherscan request failed for {address}"))?
+            .json()
+            .await
+            .with_context(|| format!("etherscan json parse failed for {address}"))?;
+
+        let status = resp.get("status").and_then(|v| v.as_str()).unwrap_or("0");
+        if status != "1" {
+            return Ok((None, None));
+        }
+
+        let entry = resp
+            .get("result")
+            .and_then(|v| v.as_array())
+            .and_then(|a| a.first())
+            .ok_or_else(|| anyhow!("etherscan getsourcecode missing result[0]"))?;
+
+        let abi_str = entry.get("ABI").and_then(|v| v.as_str()).unwrap_or("");
+        let abi = if abi_str.is_empty()
+            || abi_str.starts_with("Contract source code not verified")
+        {
+            None
+        } else {
+            Some(
+                serde_json::from_str::<JsonAbi>(abi_str)
+                    .with_context(|| format!("ABI parse failed for {address}"))?,
+            )
+        };
+
+        let impl_str = entry
+            .get("Implementation")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let impl_addr = if impl_str.is_empty() {
+            None
+        } else {
+            impl_str.parse::<Address>().ok()
+        };
+
+        Ok((abi, impl_addr))
+    }
+}

--- a/crates/cli/src/verbose/mod.rs
+++ b/crates/cli/src/verbose/mod.rs
@@ -1,0 +1,103 @@
+//! Verbose CLI mode: opt-in instrumentation that decodes state updates
+//! against Etherscan-fetched ABIs and reruns failed estimations under a
+//! tracing inspector.
+//!
+//! All side effects are hidden behind a single [`Verbose`] handle. When
+//! verbose is disabled, every method short-circuits to a no-op so callers
+//! can sprinkle hooks through `main` without `if verbose { ... }` walls.
+//!
+//! Layering:
+//! - `etherscan` — HTTP + cache (no formatting)
+//! - `decode` — pure ABI decoders over raw bytes (no I/O)
+//! - `print` — verbose printers built on top of the two above
+
+mod decode;
+mod etherscan;
+mod print;
+
+use alloy_primitives::Address;
+use colored::Colorize;
+use gas_analyzer_core::{RevertingContext, StateUpdate};
+
+#[cfg(feature = "evmsketch")]
+use gas_analyzer_evmsketch::GasKillerEvmSketchDefault;
+
+pub use etherscan::EtherscanClient;
+
+/// Verbose-mode handle. Construct with [`Verbose::new`]; methods are
+/// no-ops when verbose mode is disabled or when no Etherscan API key is
+/// available.
+pub struct Verbose {
+    /// `Some` iff verbose was requested AND `ETHERSCAN_API_KEY` is set.
+    client: Option<EtherscanClient>,
+}
+
+impl Verbose {
+    /// Build a verbose handle. When `enabled` is false, returns a handle
+    /// whose methods are all no-ops. When `enabled` is true but
+    /// `ETHERSCAN_API_KEY` is missing, prints a one-line warning and still
+    /// returns a no-op handle.
+    pub fn new(enabled: bool) -> Self {
+        if !enabled {
+            return Self { client: None };
+        }
+        match std::env::var("ETHERSCAN_API_KEY") {
+            Ok(key) => Self {
+                client: Some(EtherscanClient::new(key, 1)),
+            },
+            Err(_) => {
+                eprintln!(
+                    "{} ETHERSCAN_API_KEY not set; verbose decoding disabled",
+                    "warning:".yellow()
+                );
+                Self { client: None }
+            }
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.client.is_some()
+    }
+
+    /// Print every state update with its CALL targets ABI-decoded.
+    pub async fn print_state_updates(&self, updates: &[StateUpdate]) {
+        if let Some(c) = &self.client {
+            print::state_updates(c, updates).await;
+        }
+    }
+
+    /// Print a `RevertingContext` with the failing call and revert reason
+    /// decoded against the target's ABI.
+    pub async fn print_reverting_context(&self, ctx: &RevertingContext) {
+        if let Some(c) = &self.client {
+            print::reverting_context(c, ctx).await;
+        }
+    }
+
+    /// Rerun gas estimation under a tracing inspector that emits a per-frame
+    /// call trace to stderr. Result is discarded — the failure being
+    /// diagnosed has already been reported. No-op when verbose is off.
+    #[cfg(feature = "evmsketch")]
+    pub fn rerun_with_tracing(
+        &self,
+        gk: &GasKillerEvmSketchDefault,
+        contract_address: Address,
+        caller_address: Address,
+        state_updates: &[StateUpdate],
+    ) {
+        if !self.enabled() {
+            return;
+        }
+        eprintln!(
+            "\n{}",
+            "── Rerunning under tracing inspector (stderr) ──"
+                .yellow()
+                .bold()
+        );
+        let _ = gk.estimate_state_changes_gas_traced(
+            contract_address,
+            caller_address,
+            state_updates,
+        );
+    }
+}

--- a/crates/cli/src/verbose/mod.rs
+++ b/crates/cli/src/verbose/mod.rs
@@ -94,10 +94,7 @@ impl Verbose {
                 .yellow()
                 .bold()
         );
-        let _ = gk.estimate_state_changes_gas_traced(
-            contract_address,
-            caller_address,
-            state_updates,
-        );
+        let _ =
+            gk.estimate_state_changes_gas_traced(contract_address, caller_address, state_updates);
     }
 }

--- a/crates/cli/src/verbose/print.rs
+++ b/crates/cli/src/verbose/print.rs
@@ -17,7 +17,9 @@ use super::etherscan::EtherscanClient;
 pub async fn state_updates(client: &EtherscanClient, updates: &[StateUpdate]) {
     println!(
         "\n{}",
-        "=== Decoded State Updates (via Etherscan) ===".green().bold()
+        "=== Decoded State Updates (via Etherscan) ==="
+            .green()
+            .bold()
     );
     for (i, update) in updates.iter().enumerate() {
         match update {
@@ -55,10 +57,7 @@ pub async fn reverting_context(client: &EtherscanClient, ctx: &RevertingContext)
         }
     } else if ctx.callargs.len() >= 4 {
         let sel = hex::encode(&ctx.callargs[..4]);
-        println!(
-            "   selector 0x{} (not in ABI; try openchain.xyz)",
-            sel
-        );
+        println!("   selector 0x{} (not in ABI; try openchain.xyz)", sel);
         println!("   callargs: 0x{}", hex::encode(&ctx.callargs));
     }
 

--- a/crates/cli/src/verbose/print.rs
+++ b/crates/cli/src/verbose/print.rs
@@ -1,0 +1,114 @@
+//! Verbose-mode output rendering.
+//!
+//! These functions take an [`EtherscanClient`] reference and the data to
+//! render. They do all the I/O and formatting; callers in `main.rs` only
+//! decide *when* to invoke them.
+
+use alloy_primitives::Bytes;
+use colored::Colorize;
+use gas_analyzer_core::{RevertingContext, StateUpdate};
+
+use super::decode::{decode_call, decode_revert};
+use super::etherscan::EtherscanClient;
+
+/// Print every [`StateUpdate::Call`] with its target's ABI-decoded function
+/// name and parameters. STORE / LOG updates are printed in their default
+/// `Debug` representation.
+pub async fn state_updates(client: &EtherscanClient, updates: &[StateUpdate]) {
+    println!(
+        "\n{}",
+        "=== Decoded State Updates (via Etherscan) ===".green().bold()
+    );
+    for (i, update) in updates.iter().enumerate() {
+        match update {
+            StateUpdate::Call(call) => {
+                println!(
+                    "  [{}] CALL → {} (value={})",
+                    i,
+                    format!("0x{:x}", call.target).cyan(),
+                    call.value
+                );
+                render_call_decode(client, call.target, &call.callargs, "        ").await;
+            }
+            other => {
+                println!("  [{}] {:?}", i, other);
+            }
+        }
+    }
+    println!();
+}
+
+/// Print a [`RevertingContext`] with the failing call decoded against the
+/// target's ABI and the revert data decoded as `Error(string)`, `Panic`, or
+/// a custom error from the ABI when possible.
+pub async fn reverting_context(client: &EtherscanClient, ctx: &RevertingContext) {
+    let abi = client.fetch_abi(ctx.target).await.ok().flatten();
+
+    println!("   {}", "── Failing call ──".red().bold());
+    if let Some(abi) = abi.as_ref()
+        && let Some(decoded) = decode_call(abi, &ctx.callargs)
+    {
+        println!("   sig: {}", decoded.signature.dimmed());
+        println!("   fn:  {}", decoded.name.bold());
+        for (param, val) in &decoded.args {
+            println!("     {} = {}", param.dimmed(), val);
+        }
+    } else if ctx.callargs.len() >= 4 {
+        let sel = hex::encode(&ctx.callargs[..4]);
+        println!(
+            "   selector 0x{} (not in ABI; try openchain.xyz)",
+            sel
+        );
+        println!("   callargs: 0x{}", hex::encode(&ctx.callargs));
+    }
+
+    println!(
+        "   revertData ({} bytes): 0x{}",
+        ctx.revertData.len(),
+        hex::encode(&ctx.revertData)
+    );
+    if !ctx.revertData.is_empty()
+        && let Some(decoded) = decode_revert(abi.as_ref(), &ctx.revertData)
+    {
+        println!("   Revert: {}", decoded.red().bold());
+    }
+}
+
+async fn render_call_decode(
+    client: &EtherscanClient,
+    target: alloy_primitives::Address,
+    callargs: &Bytes,
+    indent: &str,
+) {
+    match client.fetch_abi(target).await {
+        Ok(Some(abi)) => match decode_call(&abi, callargs) {
+            Some(decoded) => {
+                println!("{indent}sig: {}", decoded.signature.dimmed());
+                println!("{indent}fn:  {}", decoded.name.bold());
+                for (param, val) in &decoded.args {
+                    println!("{indent}  {} = {}", param.dimmed(), val);
+                }
+            }
+            None => {
+                let sel = if callargs.len() >= 4 {
+                    hex::encode(&callargs[..4])
+                } else {
+                    "<short>".to_string()
+                };
+                println!(
+                    "{indent}{} (selector 0x{sel} not in ABI)",
+                    "<unknown function>".yellow()
+                );
+            }
+        },
+        Ok(None) => {
+            println!(
+                "{indent}{}",
+                "<contract not verified on Etherscan>".yellow()
+            );
+        }
+        Err(e) => {
+            println!("{indent}{} {e}", "etherscan error:".red());
+        }
+    }
+}

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -322,6 +322,35 @@ impl GasKillerEvmSketchDefault {
         )
     }
 
+    /// Estimate gas under a tracing inspector that emits a per-frame call
+    /// trace to stderr. Use this when a normal estimation produced an opaque
+    /// outer revert and you need to see which sub-call actually misbehaved.
+    ///
+    /// Same state-anchoring as `estimate_state_changes_gas` (block N-1 via
+    /// `SimpleRpcDb`); does not replay preceding-tx history. Intended as a
+    /// debug rerun, not a production estimation path.
+    pub fn estimate_state_changes_gas_traced(
+        &self,
+        contract_address: Address,
+        caller_address: Address,
+        state_updates: &[StateUpdate],
+    ) -> Result<u64> {
+        let state_block = self.executor.anchor_block_number().saturating_sub(1);
+        let simple_db = SimpleRpcDb {
+            provider: self.executor.sketch.provider.clone(),
+            block_number: state_block,
+        };
+        let mut cache_db = CacheDB::new(simple_db);
+        let sim_env = self.executor.sim_env();
+        gas_analyzer_estimator::estimate_state_changes_gas_traced(
+            &mut cache_db,
+            contract_address,
+            caller_address,
+            state_updates,
+            &sim_env,
+        )
+    }
+
     /// Estimate gas using a fallback heuristic based on the original transaction trace.
     ///
     /// This extracts operations (SSTORE, LOG, CALL) from the original transaction trace

--- a/crates/gas-estimator/src/lib.rs
+++ b/crates/gas-estimator/src/lib.rs
@@ -19,9 +19,12 @@ use revm::state::AccountInfo;
 use gas_analyzer_core::encoding::encode_state_updates_to_sol;
 use gas_analyzer_core::types::StateUpdate;
 
+mod tracing;
+pub use tracing::estimate_state_changes_gas_traced;
+
 /// EIP-7825 per-tx gas cap, activated in Osaka (Fusaka). The block gas limit
 /// can exceed this, but a single tx cannot use more than `2^24` gas.
-const EIP7825_TX_GAS_CAP: u64 = 1 << 24;
+pub(crate) const EIP7825_TX_GAS_CAP: u64 = 1 << 24;
 
 /// Environment fields for the gas estimation simulation.
 ///
@@ -44,13 +47,13 @@ const ESTIMATOR_ABI_JSON: &str = include_str!("../../../abis/StateChangeHandlerG
 
 /// Compute the isolated storage slot for the implementation address.
 /// Mirrors the Solidity constant: `keccak256("gas.estimator.implementation") - 1`
-fn impl_slot() -> U256 {
+pub(crate) fn impl_slot() -> U256 {
     U256::from_be_bytes(*alloy_primitives::keccak256("gas.estimator.implementation"))
         - U256::from(1)
 }
 
 /// Load the StateChangeHandlerGasEstimator deployed bytecode from the embedded artifact.
-fn load_estimator_bytecode() -> Result<Vec<u8>> {
+pub(crate) fn load_estimator_bytecode() -> Result<Vec<u8>> {
     let json: serde_json::Value = serde_json::from_str(ESTIMATOR_ABI_JSON)
         .map_err(|e| anyhow!("Failed to parse embedded JSON: {}", e))?;
 

--- a/crates/gas-estimator/src/tracing.rs
+++ b/crates/gas-estimator/src/tracing.rs
@@ -1,0 +1,271 @@
+//! Optional revm `Inspector` that prints a per-frame call trace to stderr
+//! and flags any frame that exits with empty returndata after consuming
+//! ≥31/32 of its forwarded gas.
+//!
+//! That signature is what AllowanceHolder's `CheckCall` propagates via
+//! `INVALID` when an inner sub-call OOGs, and what revm produces when an
+//! opcode is missing from the configured spec (`InstructionResult::NotActivated`).
+//! Surfacing it at the originating frame turns an opaque outer revert into
+//! a precise "this contract / this selector misbehaved" pointer.
+//!
+//! Mirrors `estimate_gas_raw`'s setup (proxy injection, cfg flags, sim env)
+//! so the traced run reproduces the failing one bit-for-bit.
+
+use alloy_primitives::{Address, B256, Bytes, U256};
+use anyhow::{Result, anyhow};
+use revm::context::result::ExecutionResult;
+use revm::context::{Context, TxEnv};
+use revm::context_interface::ContextTr;
+use revm::database::CacheDB;
+use revm::database_interface::DatabaseRef;
+use revm::inspector::{InspectEvm, Inspector};
+use revm::interpreter::interpreter::EthInterpreter;
+use revm::interpreter::{CallInputs, CallOutcome, CallScheme, InstructionResult};
+use revm::state::AccountInfo;
+use revm::{MainBuilder, MainContext};
+
+use crate::{
+    EIP7825_TX_GAS_CAP, SimEnvOpts, build_gas_estimation_calldata, impl_slot,
+    load_estimator_bytecode,
+};
+use gas_analyzer_core::types::StateUpdate;
+
+/// Run gas estimation under a tracing inspector. Same semantics as
+/// [`crate::estimate_state_changes_gas`], plus:
+///
+/// - every CALL frame is logged to stderr with target / caller / selector
+///   / forwarded gas / return shape;
+/// - the first frame that returns empty + nearly-OOG gets a `^^^` pointer.
+///
+/// Use this when a normal estimation produces an opaque outer revert.
+pub fn estimate_state_changes_gas_traced<DB>(
+    cache_db: &mut CacheDB<DB>,
+    contract_address: Address,
+    caller_address: Address,
+    state_updates: &[StateUpdate],
+    sim_env: &SimEnvOpts,
+) -> Result<u64>
+where
+    DB: DatabaseRef,
+    <DB as DatabaseRef>::Error: core::fmt::Debug,
+{
+    inject_proxy(cache_db, contract_address)?;
+
+    let calldata = build_gas_estimation_calldata(state_updates)?;
+
+    let ctx = Context::mainnet()
+        .with_db(&mut *cache_db)
+        .modify_cfg_chained(|cfg| {
+            cfg.disable_nonce_check = true;
+            cfg.disable_balance_check = true;
+            cfg.disable_base_fee = true;
+            cfg.disable_fee_charge = true;
+            cfg.spec = revm::primitives::hardfork::SpecId::OSAKA;
+        })
+        .modify_block_chained(|block| {
+            block.number = U256::from(sim_env.number);
+            block.timestamp = U256::from(sim_env.timestamp);
+            block.gas_limit = sim_env.gas_limit;
+            block.beneficiary = sim_env.coinbase;
+            block.prevrandao = Some(sim_env.prevrandao);
+            block.basefee = sim_env.basefee;
+            block.difficulty = U256::ZERO;
+        });
+
+    let mut evm = ctx.build_mainnet_with_inspector(CallTracer::new());
+
+    let tx = TxEnv::builder()
+        .caller(caller_address)
+        .kind(revm::primitives::TxKind::Call(contract_address))
+        .data(calldata)
+        .value(U256::ZERO)
+        .gas_limit(sim_env.gas_limit.min(EIP7825_TX_GAS_CAP))
+        .gas_price(sim_env.gas_price)
+        .build()
+        .map_err(|e| anyhow!("Failed to build tx env: {:?}", e))?;
+
+    let result = evm
+        .inspect_one_tx(tx)
+        .map_err(|e| anyhow!("Gas estimation failed: {:?}", e))?;
+
+    match result {
+        ExecutionResult::Success { gas_used, .. } => Ok(gas_used),
+        ExecutionResult::Revert { output, gas_used, .. } => Err(anyhow!(
+            "Gas estimation reverted (gas: {}): {}",
+            gas_used,
+            output
+        )),
+        ExecutionResult::Halt { reason, gas_used, .. } => Err(anyhow!(
+            "Gas estimation halted (gas: {}): {:?}",
+            gas_used,
+            reason
+        )),
+    }
+}
+
+// Same proxy-injection dance as `estimate_gas_raw`. Kept as a local helper
+// rather than refactored into the main path because `estimate_gas_raw` is
+// `where DB::Error: Debug` and we don't want the tracing module to bleed
+// generics back into the production hot path.
+fn inject_proxy<DB>(cache_db: &mut CacheDB<DB>, contract_address: Address) -> Result<()>
+where
+    DB: DatabaseRef,
+    <DB as DatabaseRef>::Error: core::fmt::Debug,
+{
+    let backup_addr = Address::from([0xba; 20]);
+
+    let original_account = cache_db
+        .basic_ref(contract_address)
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    if let Some(code) = original_account.code {
+        cache_db.insert_account_info(
+            backup_addr,
+            AccountInfo {
+                balance: U256::ZERO,
+                nonce: 0,
+                code_hash: B256::ZERO,
+                code: Some(code),
+            },
+        );
+    }
+
+    let proxy_bytes = load_estimator_bytecode()?;
+    cache_db.insert_account_info(
+        contract_address,
+        AccountInfo {
+            balance: original_account.balance,
+            nonce: 0,
+            code_hash: B256::ZERO,
+            code: Some(revm::state::Bytecode::new_raw(proxy_bytes.into())),
+        },
+    );
+
+    let backup_addr_u256 = U256::from_be_slice(backup_addr.as_slice());
+    cache_db
+        .insert_account_storage(contract_address, impl_slot(), backup_addr_u256)
+        .map_err(|e| anyhow!("Failed to write IMPL_SLOT: {:?}", e))?;
+
+    Ok(())
+}
+
+/// Per-frame stash captured at `call` so we can compute a meaningful
+/// `gas_spent` and flag suspicious exits at `call_end`.
+struct Frame {
+    target: Address,
+    caller: Address,
+    scheme: CallScheme,
+    gas_limit: u64,
+    selector: [u8; 4],
+    input_len: usize,
+}
+
+struct CallTracer {
+    frames: Vec<Frame>,
+    /// Cap depth at which we still print to stderr. Keeps very deep call
+    /// trees from flooding output while still letting us capture the
+    /// first failure marker (which is recorded regardless of depth).
+    max_depth: usize,
+    /// Throttle: only print the first empty-revert+gas-consumed pointer.
+    /// Subsequent ones are usually parents bubbling up the same failure.
+    printed_failure: bool,
+}
+
+impl CallTracer {
+    fn new() -> Self {
+        Self {
+            frames: Vec::new(),
+            max_depth: 256,
+            printed_failure: false,
+        }
+    }
+}
+
+impl<CTX> Inspector<CTX, EthInterpreter> for CallTracer
+where
+    CTX: ContextTr,
+{
+    fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        let depth = self.frames.len();
+        let bytes: Bytes = inputs.input.bytes(ctx);
+        let mut selector = [0u8; 4];
+        if bytes.len() >= 4 {
+            selector.copy_from_slice(&bytes[..4]);
+        }
+
+        if depth < self.max_depth {
+            eprintln!(
+                "[trace] {}CALL → {} (from {}) gas_limit={} sel=0x{} input_len={} scheme={:?}",
+                "  ".repeat(depth),
+                inputs.target_address,
+                inputs.caller,
+                inputs.gas_limit,
+                hex::encode(selector),
+                bytes.len(),
+                inputs.scheme,
+            );
+        }
+
+        self.frames.push(Frame {
+            target: inputs.target_address,
+            caller: inputs.caller,
+            scheme: inputs.scheme,
+            gas_limit: inputs.gas_limit,
+            selector,
+            input_len: bytes.len(),
+        });
+        None
+    }
+
+    fn call_end(&mut self, _ctx: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
+        let frame = self.frames.pop();
+        let depth = self.frames.len();
+        let result = outcome.result.result;
+        let gas_remaining = outcome.result.gas.remaining();
+        let out_len = outcome.result.output.len();
+        let gas_spent = frame
+            .as_ref()
+            .map(|f| f.gas_limit.saturating_sub(gas_remaining))
+            .unwrap_or(0);
+
+        let is_fail = !matches!(result, InstructionResult::Return | InstructionResult::Stop);
+
+        if depth < self.max_depth {
+            eprintln!(
+                "[trace] {}END  {:?} gas_spent={} returndata_len={}",
+                "  ".repeat(depth),
+                result,
+                gas_spent,
+                out_len,
+            );
+        }
+
+        if is_fail && out_len == 0 && !self.printed_failure
+            && let Some(f) = frame
+        {
+            // EIP-150 forwards (1 - 1/64) of available gas to the callee, so
+            // a callee that OOGs leaves the parent with ~gas_limit/32 remaining
+            // (≈ the (1/64)^2 we'd see across one proxy hop). Anything below
+            // that threshold is the OOG signature CheckCall escalates to
+            // INVALID, OR a `NotActivated` opcode under the wrong spec.
+            let threshold = (f.gas_limit / 32).max(1);
+            if gas_remaining <= threshold {
+                eprintln!(
+                    "[trace] {}^^^ EMPTY-REVERT + GAS-CONSUMED in frame: target={} caller={} sel=0x{} input_len={} scheme={:?} gas_limit={} gas_remaining={} (≤ limit/32 = {})",
+                    "  ".repeat(depth),
+                    f.target,
+                    f.caller,
+                    hex::encode(f.selector),
+                    f.input_len,
+                    f.scheme,
+                    f.gas_limit,
+                    gas_remaining,
+                    threshold,
+                );
+                self.printed_failure = true;
+            }
+        }
+    }
+}

--- a/crates/gas-estimator/src/tracing.rs
+++ b/crates/gas-estimator/src/tracing.rs
@@ -90,12 +90,16 @@ where
 
     match result {
         ExecutionResult::Success { gas_used, .. } => Ok(gas_used),
-        ExecutionResult::Revert { output, gas_used, .. } => Err(anyhow!(
+        ExecutionResult::Revert {
+            output, gas_used, ..
+        } => Err(anyhow!(
             "Gas estimation reverted (gas: {}): {}",
             gas_used,
             output
         )),
-        ExecutionResult::Halt { reason, gas_used, .. } => Err(anyhow!(
+        ExecutionResult::Halt {
+            reason, gas_used, ..
+        } => Err(anyhow!(
             "Gas estimation halted (gas: {}): {:?}",
             gas_used,
             reason
@@ -242,7 +246,9 @@ where
             );
         }
 
-        if is_fail && out_len == 0 && !self.printed_failure
+        if is_fail
+            && out_len == 0
+            && !self.printed_failure
             && let Some(f) = frame
         {
             // EIP-150 forwards (1 - 1/64) of available gas to the callee, so


### PR DESCRIPTION
Adds an opt-in `-v` / `--verbose` mode for debugging failed estimations. Stacked on top of #122 — merge that first.

## What it does

When `--verbose` is passed and `ETHERSCAN_API_KEY` is set, three extra things happen at well-defined hook points; otherwise output is unchanged.

1. **Decoded state updates** — before estimation runs, every `StateUpdate::Call` is printed with its target's ABI-decoded function name, signature, and per-parameter values. Verified proxies are followed into their implementation ABI so proxied selectors decode (USDC `permit`/`transferFrom` etc.).

2. **Decoded RevertingContext** — when measured estimation fails with a `RevertingContext`, the failing call's args are decoded against the target's ABI and the revert data is decoded as `Error(string)`, `Panic(uint256)`, or any custom error in the ABI. Bytes from the trace stop being opaque.

3. **Traced rerun** — the failed estimation is re-executed under a revm `Inspector` that emits a per-frame call trace to stderr and flags the first frame that exits with empty returndata after consuming ≥31/32 of its forwarded gas. That signature is what both AllowanceHolder's `CheckCall`-via-`INVALID` and revm's `InstructionResult::NotActivated` produce on the parent — so the marker points directly at the originating frame instead of the bubbled-up outer revert. (This mode is what we used to identify Ekubo Core's `CLZ` opcode in the parent PR's debugging.)

## Modularization

```
crates/cli/src/verbose/
  mod.rs        - Verbose handle (no-op when disabled), public surface
  etherscan.rs  - Etherscan v2 client + per-address cache (HTTP only)
  decode.rs     - pure ABI decoders over raw bytes (no I/O)
  print.rs      - verbose printers built on top of the two above

crates/gas-estimator/src/
  tracing.rs    - CallTracer Inspector + estimate_state_changes_gas_traced
```

A single `Verbose` handle exposes async no-op-when-disabled methods so `main.rs` reads as a thin sequence of `verbose.print_state_updates(...)`, `verbose.print_reverting_context(...)`, `verbose.rerun_with_tracing(...)` — no `if verbose { ... }` walls.

`evmsketch` gains one thin `estimate_state_changes_gas_traced` wrapper that anchors at block N-1 via `SimpleRpcDb` and forwards into the gas-estimator's traced variant.

## Layering invariants

- `etherscan.rs` only does HTTP + caching, no formatting.
- `decode.rs` is pure: takes `&JsonAbi` and `&[u8]`, no I/O, no `println`.
- `print.rs` does all the formatting; only place that imports `colored`.
- The CLI never touches revm types directly — the inspector is fully contained in the gas-estimator crate.

## Help output

```
Flags:

  --anvil          Use Anvil-based implementation (requires --features anvil)
  --debug          Print full error details including RPC errors
  -v / --verbose   ABI-decode state updates and trace failed estimations
                   (requires ETHERSCAN_API_KEY environment variable)
```

## Test plan

- [x] Default (no `--verbose`) output unchanged
- [x] `--verbose` on a successful tx prints decoded state updates and the same final gas estimate
- [x] `--verbose` falls back gracefully if `ETHERSCAN_API_KEY` is missing (warning + run continues)
- [x] `--verbose` on a previously-failing tx (pre-Osaka-fix) printed the full call trace and pinpointed the `NotActivated`/empty-revert frame — that's how we found the `CLZ` issue in #122
