### PR TITLE
Add tracing spans and update CLI to print details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,7 +3274,6 @@ dependencies = [
  "gas-analyzer-rpc",
  "hex",
  "tokio",
- "tracing",
  "tracing-subscriber 0.3.23",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -3274,6 +3274,8 @@ dependencies = [
  "gas-analyzer-rpc",
  "hex",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
@@ -3288,6 +3290,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -3305,6 +3308,7 @@ dependencies = [
  "hex",
  "revm 31.0.2",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -3330,6 +3334,7 @@ dependencies = [
  "sp1-cc-host-executor",
  "tokio",
  "tower",
+ "tracing",
  "url",
 ]
 
@@ -4237,6 +4242,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -7256,6 +7270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8417,12 +8440,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,6 @@ alloy-eips = "1.0.37"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 colored = "3.0.0"
-tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenv = "0.15.0"
 hex = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,8 @@ alloy-eips = "1.0.37"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 colored = "3.0.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dotenv = "0.15.0"
 hex = "0.4"
 tokio = { version = "1.45.1", features = ["rt-multi-thread"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -85,6 +85,16 @@ async fn main() {
     dotenv::dotenv().ok();
     let cli_args = parse_args();
 
+    let log_level = if cli_args.debug { "debug" } else { "info" };
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(log_level)),
+        )
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_target(false)
+        .init();
+
     let debug = cli_args.debug;
     let result = execute_command(cli_args).await;
     if let Err(e) = result {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
 anyhow = "1.0.98"
+tracing = "0.1"

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -165,6 +165,7 @@ pub fn append_state_update_from_struct_log(
 ///
 /// Returns: (state_updates, skipped_opcodes, call_gas_total)
 /// - `call_gas_total` is the total gas cost of all CALL operations in state_updates
+#[tracing::instrument(name = "gas.trace_parse", skip_all, fields(state_update_count = tracing::field::Empty))]
 pub fn compute_state_updates(
     trace: DefaultFrame,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>, u64)> {
@@ -257,6 +258,7 @@ pub fn compute_state_updates(
         );
     }
 
+    tracing::Span::current().record("state_update_count", state_updates.len());
     Ok((state_updates, skipped_opcodes, total_call_gas))
 }
 

--- a/crates/evmsketch/Cargo.toml
+++ b/crates/evmsketch/Cargo.toml
@@ -13,6 +13,7 @@ alloy-evm = "0.25"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 tokio = { version = "1", features = ["rt"] }
+tracing = "0.1"
 url = "2.5.4"
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.1" }
 revm = { version = "31.0.1" }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -280,6 +280,7 @@ impl GasKillerEvmSketchBuilder {
     }
 
     /// Build the GasKillerEvmSketch instance.
+    #[tracing::instrument(name = "evmsketch.build", skip(self), fields(block_number = %self.block))]
     pub async fn build(self) -> Result<GasKillerEvmSketchDefault> {
         let executor = EvmSketchExecutorBuilder::new()
             .rpc_url(self.rpc_url)
@@ -311,6 +312,7 @@ impl GasKillerEvmSketchDefault {
     /// backed by standard RPC calls (`eth_getStorageAt`, `eth_getBalance`, etc.)
     /// instead of sp1-cc's `BasicRpcDb` which requires `eth_getProof`. This avoids
     /// the "proof window" limitation on Reth and other nodes.
+    #[tracing::instrument(name = "evmsketch.estimate", skip_all, fields(block_number = self.executor.anchor_block_number(), state_update_count = state_updates.len()))]
     pub fn estimate_state_changes_gas(
         &self,
         contract_address: Address,
@@ -429,6 +431,7 @@ impl GasKillerEvmSketchDefault {
 ///
 /// # Returns
 /// `(storage_updates, gas_estimate, is_heuristic, skipped_opcodes)`
+#[tracing::instrument(name = "evmsketch.encode", skip_all, fields(block_number = %block, state_update_count = tracing::field::Empty))]
 pub async fn call_to_encoded_state_updates_with_evmsketch(
     rpc_url: impl AsRef<str>,
     tx_request: TransactionRequest,
@@ -451,6 +454,7 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
     let block_id = BlockId::Number(block);
     let trace = get_trace_from_call(&provider, tx_request, block_id).await?;
     let (state_updates, skipped_opcodes, _call_gas_total) = compute_state_updates(trace)?;
+    tracing::Span::current().record("state_update_count", state_updates.len());
 
     let storage_updates = encode_state_updates_to_abi(&state_updates);
 

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -37,6 +37,7 @@ pub struct SimpleRpcDb {
 impl DatabaseRef for SimpleRpcDb {
     type Error = SimpleRpcDbError;
 
+    #[tracing::instrument(name = "evmsketch.rpc.account", skip_all, level = "debug", fields(block_number = self.block_number, rpc_call_count = 3u32))]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let handle =
             tokio::runtime::Handle::try_current().map_err(|e| format!("no tokio runtime: {e}"))?;
@@ -80,6 +81,7 @@ impl DatabaseRef for SimpleRpcDb {
             .into())
     }
 
+    #[tracing::instrument(name = "evmsketch.rpc.storage", skip_all, level = "debug", fields(block_number = self.block_number, rpc_call_count = 1u32))]
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let handle =
             tokio::runtime::Handle::try_current().map_err(|e| format!("no tokio runtime: {e}"))?;

--- a/crates/gas-estimator/Cargo.toml
+++ b/crates/gas-estimator/Cargo.toml
@@ -10,6 +10,7 @@ alloy-dyn-abi = "1.0.37"
 hex = "0.4"
 anyhow = "1.0.98"
 serde_json = "1.0"
+tracing = "0.1"
 revm = { version = "31.0.1", default-features = false, features = [
     "std",
     "optional_balance_check",

--- a/crates/gas-estimator/src/lib.rs
+++ b/crates/gas-estimator/src/lib.rs
@@ -271,6 +271,7 @@ where
 /// * `caller_address` - The address to use as the caller (also used as tx.origin)
 /// * `state_updates` - The state updates to estimate gas for
 /// * `sim_env` - Simulation environment fields (block and tx context)
+#[tracing::instrument(name = "gas.evm_execute", skip_all, fields(block_number = sim_env.number, state_update_count = state_updates.len()))]
 pub fn estimate_state_changes_gas<DB>(
     cache_db: &mut CacheDB<DB>,
     contract_address: Address,


### PR DESCRIPTION
## Summary
- Adds `#[tracing::instrument]` spans to the evmsketch critical path so latency can be measured per-stage in production
- Wires a `tracing-subscriber` fmt subscriber into the CLI so span timings print on every run without any extra setup

## Spans added

| Span | Location | Fields |
|---|---|---|
| `evmsketch.encode` | `call_to_encoded_state_updates_with_evmsketch` | `block_number`, `state_update_count` |
| `evmsketch.build` | `GasKillerEvmSketchBuilder::build` | `block_number` |
| `evmsketch.estimate` | `GasKillerEvmSketch::estimate_state_changes_gas` | `block_number`, `state_update_count` |
| `evmsketch.rpc.account` | `SimpleRpcDb::basic_ref` | `block_number`, `rpc_call_count=3` (debug) |
| `evmsketch.rpc.storage` | `SimpleRpcDb::storage_ref` | `block_number`, `rpc_call_count=1` (debug) |
| `gas.trace_parse` | `compute_state_updates` | `state_update_count` |
| `gas.evm_execute` | `estimate_state_changes_gas` | `block_number`, `state_update_count` |

## CLI behaviour

```
# INFO level — top-level spans only (build, encode, trace_parse, estimate, evm_execute):
cargo run -- t <TX_HASH>

# DEBUG level — also shows per-slot RPC spans:
cargo run -- t <TX_HASH> --debug
```

`RUST_LOG` overrides the default if finer control is needed (e.g. `RUST_LOG=gas_analyzer_evmsketch=debug`).

## Notes
- Zero overhead when no subscriber is registered — standard `tracing` guarantee
- Compatible with `tracing-opentelemetry` + OTLP for future production export; the subscriber is wired here only at the CLI level, not in the libraries
- Closes #120