### PR TITLE
Same CI runner for bench workflow

### DIFF
--- a/.github/scripts/check_regressions.py
+++ b/.github/scripts/check_regressions.py
@@ -72,9 +72,8 @@ def build_report(
             )
 
     footer = (
-        "<sub>Benchmarks run on shared GitHub-hosted runners. "
-        f"Hardware variance may cause false positives — "
-        f"only regressions >{threshold:.0f}% are flagged.</sub>"
+        "<sub>Base and candidate benchmarks run back-to-back on the same CI runner. "
+        f"Only regressions >{threshold:.0f}% are flagged.</sub>"
     )
 
     if not baseline:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,11 +8,13 @@ env:
 
 jobs:
   # ────────────────────────────────────────────────────────────────────────
-  # On every PR: bench the base branch and the PR branch back-to-back on the
+  # On every PR: bench the PR branch and the base branch back-to-back on the
   # same runner, post a sticky comment with the regression report, and fail
   # if any offline metric regresses beyond 15 %.
   #
   # Running both measurements in one job eliminates cross-machine variance.
+  # The candidate runs FIRST so that any warm-cache ordering bias works
+  # against the candidate rather than masking regressions.
   # Fixtures are pulled once from LFS after the initial checkout; they
   # persist on disk through the branch switch since target/ is gitignored.
   #
@@ -29,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Pull bench fixtures from LFS
@@ -38,14 +40,22 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Bench base branch (baseline)
-        run: make bench-save-baseline
-
-      - name: Switch to PR branch
-        run: git checkout ${{ github.event.pull_request.head.sha }}
+      - name: Clear any stale Criterion data
+        run: rm -rf target/criterion/
 
       - name: Bench PR branch (candidate)
-        run: make bench-compare
+        run: make bench-save-baseline BASELINE=new
+
+      - name: Switch to base branch
+        run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Flush page cache and allocator
+        run: |
+          sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'
+          python3 -c "import ctypes; ctypes.CDLL('libc.so.6').malloc_trim(0)"
+
+      - name: Bench base branch (baseline)
+        run: make bench-save-baseline
 
       - name: Check regressions and generate report
         id: regcheck

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,20 +44,10 @@ jobs:
         run: rm -rf target/criterion/
 
       - name: Bench PR branch (candidate)
-        run: make bench-save-baseline BASELINE=new
-
-      # Criterion 0.5 leaves benchmark.json empty on first write; the baseline
-      # run would find the empty file and overwrite the new/ directory with its
-      # own data, making both baselines identical (all 0% changes). Save the
-      # candidate results before switching branches and restore them after.
-      - name: Preserve candidate Criterion data
-        run: cp -r target/criterion/ /tmp/criterion-candidate/
+        run: make bench-save-baseline BASELINE=candidate
 
       - name: Switch to base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
-
-      - name: Clear Criterion data for baseline run
-        run: rm -rf target/criterion/
 
       - name: Flush page cache and allocator
         run: |
@@ -67,9 +57,6 @@ jobs:
       - name: Bench base branch (baseline)
         run: make bench-save-baseline
 
-      - name: Restore candidate data for comparison
-        run: cp -rn /tmp/criterion-candidate/. target/criterion/
-
       - name: Check regressions and generate report
         id: regcheck
         continue-on-error: true
@@ -77,6 +64,7 @@ jobs:
           python3 .github/scripts/check_regressions.py \
             --threshold 15 \
             --criterion-dir target/criterion \
+            --candidate candidate \
             --output-file regression-report.md
 
       - name: Post PR comment

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,8 +46,18 @@ jobs:
       - name: Bench PR branch (candidate)
         run: make bench-save-baseline BASELINE=new
 
+      # Criterion 0.5 leaves benchmark.json empty on first write; the baseline
+      # run would find the empty file and overwrite the new/ directory with its
+      # own data, making both baselines identical (all 0% changes). Save the
+      # candidate results before switching branches and restore them after.
+      - name: Preserve candidate Criterion data
+        run: cp -r target/criterion/ /tmp/criterion-candidate/
+
       - name: Switch to base branch
         run: git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Clear Criterion data for baseline run
+        run: rm -rf target/criterion/
 
       - name: Flush page cache and allocator
         run: |
@@ -56,6 +66,9 @@ jobs:
 
       - name: Bench base branch (baseline)
         run: make bench-save-baseline
+
+      - name: Restore candidate data for comparison
+        run: cp -rn /tmp/criterion-candidate/. target/criterion/
 
       - name: Check regressions and generate report
         id: regcheck

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,6 @@
 name: Benchmarks
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 env:
@@ -10,56 +8,29 @@ env:
 
 jobs:
   # ────────────────────────────────────────────────────────────────────────
-  # On every push to main: save a Criterion baseline for all offline benches
-  # and upload it as a named artifact for PR jobs to compare against.
+  # On every PR: bench the base branch and the PR branch back-to-back on the
+  # same runner, post a sticky comment with the regression report, and fail
+  # if any offline metric regresses beyond 15 %.
   #
-  # All fixtures are stored in Git LFS.  If LFS bandwidth is exhausted
-  # the pull fails gracefully; any bench whose fixture is missing skips
-  # cleanly and the remaining benches still save their baselines.
-  # ────────────────────────────────────────────────────────────────────────
-  bench-save:
-    name: Save baseline
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Pull bench fixtures from LFS
-        continue-on-error: true
-        run: git lfs pull --include "crates/evmsketch/benches/fixtures/"
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Save Criterion baseline
-        run: make bench-save-baseline
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: bench-baseline
-          path: target/criterion/
-          retention-days: 90
-          overwrite: true
-
-  # ────────────────────────────────────────────────────────────────────────
-  # On every PR: compare benchmarks against the saved main baseline, post a
-  # sticky comment with the regression report, and fail if any offline metric
-  # regresses beyond 15 %.
+  # Running both measurements in one job eliminates cross-machine variance.
+  # Fixtures are pulled once from LFS after the initial checkout; they
+  # persist on disk through the branch switch since target/ is gitignored.
   #
   # end_to_end is excluded — it requires a live Sepolia node and is dominated
   # by network latency, making it unsuitable for threshold-based regression
   # detection.
   # ────────────────────────────────────────────────────────────────────────
-  bench-compare:
+  bench:
     name: Benchmark regression check
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
 
       - name: Pull bench fixtures from LFS
         continue-on-error: true
@@ -67,39 +38,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # Fetch the most recent successful bench-save run on main and download
-      # its baseline artifact.  Skips gracefully when no baseline exists yet
-      # (first PR before main has ever run this workflow).
-      - name: Download main baseline
-        id: baseline
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RUN_ID=$(gh run list \
-            --repo "$GITHUB_REPOSITORY" \
-            --workflow bench.yml \
-            --branch main \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty' 2>/dev/null || true)
-          if [ -n "$RUN_ID" ]; then
-            gh run download "$RUN_ID" \
-              --repo "$GITHUB_REPOSITORY" \
-              --name bench-baseline \
-              --dir target/criterion/ \
-              && echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::No successful bench-save run found on main — running benchmarks for reference only."
-          fi
+      - name: Bench base branch (baseline)
+        run: make bench-save-baseline
 
-      - name: Run benchmarks (with comparison)
-        if: steps.baseline.outputs.found == 'true'
+      - name: Switch to PR branch
+        run: git checkout ${{ github.event.pull_request.head.sha }}
+
+      - name: Bench PR branch (candidate)
         run: make bench-compare
-
-      - name: Run benchmarks (reference only — no baseline)
-        if: steps.baseline.outputs.found != 'true'
-        run: make bench
 
       - name: Check regressions and generate report
         id: regcheck


### PR DESCRIPTION
Run baseline and candidate benches on the same runner for better compare (runner has same resources). Add a "cache clear" step to reduce variance between cold and warm runs.