### PR TITLE
Use get proof when available, fallback to parallelized calls to get account details

### DIFF
--- a/crates/evmsketch/benches/fixtures/generate_replay_fixture.rs
+++ b/crates/evmsketch/benches/fixtures/generate_replay_fixture.rs
@@ -152,10 +152,7 @@ async fn run(rpc_url: String) -> Result<()> {
     // from the chain on demand.  After replay the cache keys tell us exactly
     // which accounts and slots need to be in the offline fixture.
     let state_block = block_number.saturating_sub(1);
-    let simple_db = SimpleRpcDb {
-        provider: any_provider,
-        block_number: state_block,
-    };
+    let simple_db = SimpleRpcDb::new(any_provider, state_block);
     let mut cache_db = CacheDB::new(simple_db);
 
     eprintln!("Replaying {tx_index} preceding txs to warm the cache (makes RPC calls)...");

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -188,10 +188,7 @@ impl DefaultEvmSketchExecutor {
         gas_price: u128,
     ) -> Result<u64> {
         let state_block = self.anchor_block_number().saturating_sub(1);
-        let simple_db = SimpleRpcDb {
-            provider: self.sketch.provider.clone(),
-            block_number: state_block,
-        };
+        let simple_db = SimpleRpcDb::new(self.sketch.provider.clone(), state_block);
         let mut cache_db = CacheDB::new(simple_db);
         let mut sim_env = self.sim_env();
         sim_env.gas_price = gas_price;
@@ -322,10 +319,7 @@ impl GasKillerEvmSketchDefault {
     ) -> Result<u64> {
         // Use block_number - 1 (pre-transaction state), matching the Anvil path.
         let state_block = self.executor.anchor_block_number().saturating_sub(1);
-        let simple_db = SimpleRpcDb {
-            provider: self.executor.sketch.provider.clone(),
-            block_number: state_block,
-        };
+        let simple_db = SimpleRpcDb::new(self.executor.sketch.provider.clone(), state_block);
         let mut cache_db = CacheDB::new(simple_db);
         let sim_env = self.executor.sim_env();
         gas_analyzer_estimator::estimate_state_changes_gas(
@@ -370,10 +364,7 @@ impl GasKillerEvmSketchDefault {
         // tx, causing signature recovery to mismatch and the call to revert
         // with "invalid signature".
         let state_block = self.executor.anchor_block_number().saturating_sub(1);
-        let simple_db = SimpleRpcDb {
-            provider: self.executor.sketch.provider.clone(),
-            block_number: state_block,
-        };
+        let simple_db = SimpleRpcDb::new(self.executor.sketch.provider.clone(), state_block);
         let mut cache_db = CacheDB::new(simple_db);
         let mut sim_env = self.executor.sim_env();
 
@@ -639,10 +630,7 @@ mod tests {
         let client = RpcClient::new(transport, true);
         let provider: RootProvider<AnyNetwork> = RootProvider::new(client);
 
-        let db = SimpleRpcDb {
-            provider,
-            block_number: 99,
-        };
+        let db = SimpleRpcDb::new(provider, 99);
 
         // SimpleRpcDb's storage_ref blocks the current thread; spawn_blocking
         // gives it the worker thread it needs under multi_thread runtime.

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -1,8 +1,11 @@
-use alloy::primitives::{Address, B256, U256};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::Provider;
 use alloy_provider::RootProvider;
 use alloy_provider::network::AnyNetwork;
 use revm::database_interface::{DBErrorMarker, DatabaseRef};
+use revm::primitives::KECCAK_EMPTY;
 use revm::state::{AccountInfo, Bytecode};
 
 /// Error type for [`SimpleRpcDb`].
@@ -24,54 +27,64 @@ impl From<String> for SimpleRpcDbError {
     }
 }
 
+/// Outcome of an `eth_getProof` attempt. Kept private to this module.
+enum GetProofOutcome {
+    Ok(AccountInfo),
+    /// The RPC endpoint explicitly does not support `eth_getProof`
+    /// (JSON-RPC error code -32601 "Method not found", or provider-specific
+    /// equivalents). Transient errors (network, timeout) do NOT produce this
+    /// variant — only an explicit unsupported-method response does.
+    MethodNotSupported,
+    /// A real error that should be surfaced to the caller.
+    Err(SimpleRpcDbError),
+}
+
+/// Returns `true` only when an error is an explicit JSON-RPC "Method not found"
+/// response (-32601). Transient failures (connection reset, timeout, etc.)
+/// are left to propagate normally.
+fn is_method_not_found<E: std::fmt::Display>(err: &E) -> bool {
+    let s = err.to_string();
+    // JSON-RPC standard code for "Method not found".
+    // All compliant providers embed -32601 in the error response.
+    // Transient errors (IO, timeout, HTTP 5xx) never contain this code.
+    s.contains("-32601")
+        || s.to_lowercase().contains("method not found")
+        || s.to_lowercase().contains("eth_getproof is not supported")
+}
+
 /// A minimal revm database backed by standard RPC calls.
 ///
-/// Unlike sp1-cc's `BasicRpcDb`, this avoids `eth_getProof` entirely and uses
-/// `eth_getBalance` / `eth_getCode` / `eth_getStorageAt` instead. These methods
-/// work on any full or archive node without requiring a proof window configuration.
+/// `basic_ref` attempts `eth_getProof` + `eth_getCode` concurrently (≤2 RPCs per
+/// account). When the RPC endpoint explicitly rejects `eth_getProof` with a
+/// "method not found" response, the `proof_supported` flag is cleared and all
+/// subsequent calls use concurrent `eth_getBalance` / `eth_getTransactionCount` /
+/// `eth_getCode` via `tokio::join!` (3 RPCs in parallel, not in series). Transient
+/// errors are propagated to the caller and do not affect the fallback state.
 pub struct SimpleRpcDb {
     pub provider: RootProvider<AnyNetwork>,
     pub block_number: u64,
+    /// Cleared after the first explicit "method not found" response from
+    /// `eth_getProof`. Subsequent calls skip the attempt entirely.
+    proof_supported: AtomicBool,
+}
+
+impl SimpleRpcDb {
+    pub fn new(provider: RootProvider<AnyNetwork>, block_number: u64) -> Self {
+        Self {
+            provider,
+            block_number,
+            proof_supported: AtomicBool::new(true),
+        }
+    }
 }
 
 impl DatabaseRef for SimpleRpcDb {
     type Error = SimpleRpcDbError;
 
-    #[tracing::instrument(name = "evmsketch.rpc.account", skip_all, level = "debug", fields(block_number = self.block_number, rpc_call_count = 3u32))]
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let handle =
             tokio::runtime::Handle::try_current().map_err(|e| format!("no tokio runtime: {e}"))?;
-        tokio::task::block_in_place(|| {
-            handle.block_on(async {
-                let block = self.block_number;
-                let balance = self
-                    .provider
-                    .get_balance(address)
-                    .number(block)
-                    .await
-                    .map_err(|e| format!("get_balance failed for {address}: {e}"))?;
-                let nonce = self
-                    .provider
-                    .get_transaction_count(address)
-                    .number(block)
-                    .await
-                    .map_err(|e| format!("get_nonce failed for {address}: {e}"))?;
-                let code_bytes = self
-                    .provider
-                    .get_code_at(address)
-                    .number(block)
-                    .await
-                    .map_err(|e| format!("get_code_at failed for {address}: {e}"))?;
-                let bytecode = Bytecode::new_raw(code_bytes);
-                let code_hash = bytecode.hash_slow();
-                Ok(Some(AccountInfo {
-                    balance,
-                    nonce,
-                    code_hash,
-                    code: Some(bytecode),
-                }))
-            })
-        })
+        tokio::task::block_in_place(|| handle.block_on(self.fetch_account(address)))
     }
 
     fn code_by_hash_ref(&self, _: B256) -> Result<Bytecode, Self::Error> {
@@ -110,5 +123,143 @@ impl DatabaseRef for SimpleRpcDb {
             })
         })
         .map_err(Into::into)
+    }
+}
+
+impl SimpleRpcDb {
+    /// Dispatch to the proof path or parallel fallback.
+    ///
+    /// Only clears `proof_supported` when the RPC explicitly rejects the method.
+    /// All other errors (including transient failures) are returned to the caller.
+    async fn fetch_account(
+        &self,
+        address: Address,
+    ) -> Result<Option<AccountInfo>, SimpleRpcDbError> {
+        if self.proof_supported.load(Ordering::Relaxed) {
+            match self.try_fetch_with_proof(address).await {
+                GetProofOutcome::Ok(info) => return Ok(Some(info)),
+                GetProofOutcome::MethodNotSupported => {
+                    self.proof_supported.store(false, Ordering::Relaxed);
+                    tracing::debug!(
+                        address = %address,
+                        "eth_getProof is not supported by this RPC endpoint; \
+                         switching permanently to parallel fallback"
+                    );
+                }
+                GetProofOutcome::Err(e) => return Err(e),
+            }
+        }
+        self.fetch_account_parallel(address).await.map(Some)
+    }
+
+    /// Attempt to fetch account metadata via `eth_getProof`.
+    ///
+    /// `eth_getProof` and `eth_getCode` are issued concurrently. The code result
+    /// is discarded for EOAs (code_hash == KECCAK_EMPTY).
+    ///
+    /// Returns [`GetProofOutcome::MethodNotSupported`] when the RPC responds with
+    /// a "method not found" error (-32601). All other errors become
+    /// [`GetProofOutcome::Err`] and are surfaced to the caller unchanged.
+    #[tracing::instrument(name = "evmsketch.rpc.account.proof", skip_all, level = "debug", fields(block_number = self.block_number))]
+    async fn try_fetch_with_proof(&self, address: Address) -> GetProofOutcome {
+        let block = self.block_number;
+
+        let (proof_res, code_res) = tokio::join!(
+            self.provider.get_proof(address, vec![]).number(block),
+            self.provider.get_code_at(address).number(block),
+        );
+
+        let proof = match proof_res {
+            Ok(p) => p,
+            Err(e) if is_method_not_found(&e) => return GetProofOutcome::MethodNotSupported,
+            Err(e) => {
+                return GetProofOutcome::Err(format!("get_proof failed for {address}: {e}").into());
+            }
+        };
+
+        let bytecode = if proof.code_hash != KECCAK_EMPTY {
+            match code_res {
+                Ok(code_bytes) => Bytecode::new_raw(code_bytes),
+                Err(e) => {
+                    return GetProofOutcome::Err(
+                        format!("get_code_at failed for {address}: {e}").into(),
+                    );
+                }
+            }
+        } else {
+            Bytecode::new_raw(Bytes::new())
+        };
+
+        GetProofOutcome::Ok(AccountInfo {
+            balance: proof.balance,
+            nonce: proof.nonce,
+            code_hash: proof.code_hash,
+            code: Some(bytecode),
+        })
+    }
+
+    /// Fetch account metadata via 3 concurrent RPCs when `eth_getProof` is unavailable.
+    ///
+    /// All three calls are issued simultaneously; total latency is bounded by
+    /// the slowest call rather than the sum of all three.
+    #[tracing::instrument(name = "evmsketch.rpc.account.parallel", skip_all, level = "debug", fields(block_number = self.block_number, rpc_call_count = 3u32))]
+    async fn fetch_account_parallel(
+        &self,
+        address: Address,
+    ) -> Result<AccountInfo, SimpleRpcDbError> {
+        let block = self.block_number;
+
+        let (balance_res, nonce_res, code_res) = tokio::join!(
+            self.provider.get_balance(address).number(block),
+            self.provider.get_transaction_count(address).number(block),
+            self.provider.get_code_at(address).number(block),
+        );
+
+        let balance = balance_res.map_err(|e| format!("get_balance failed for {address}: {e}"))?;
+        let nonce = nonce_res.map_err(|e| format!("get_nonce failed for {address}: {e}"))?;
+        let code_bytes = code_res.map_err(|e| format!("get_code_at failed for {address}: {e}"))?;
+        let bytecode = Bytecode::new_raw(code_bytes);
+        let code_hash = bytecode.hash_slow();
+
+        Ok(AccountInfo {
+            balance,
+            nonce,
+            code_hash,
+            code: Some(bytecode),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `is_method_not_found` must accept the canonical JSON-RPC -32601 error
+    /// string and common provider-specific variants, while rejecting transient
+    /// failures that should propagate to the caller.
+    #[test]
+    fn test_is_method_not_found_detection() {
+        // Standard alloy error display for -32601
+        assert!(is_method_not_found(
+            &"server returned an error response: error code -32601: Method not found"
+        ));
+        // Short form that some providers emit
+        assert!(is_method_not_found(&"error code -32601: method not found"));
+        // Provider that spells out the method name
+        assert!(is_method_not_found(
+            &"eth_getProof is not supported on this endpoint"
+        ));
+        // Generic "method not found" without an error code
+        assert!(is_method_not_found(&"Method not found"));
+
+        // Transient errors — must NOT trigger fallback
+        assert!(!is_method_not_found(&"connection reset by peer"));
+        assert!(!is_method_not_found(&"request timed out"));
+        assert!(!is_method_not_found(
+            &"server returned an error response: error code -32000: execution reverted"
+        ));
+        assert!(!is_method_not_found(
+            &"server returned an error response: error code -32603: internal error"
+        ));
     }
 }

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::Provider;
+use alloy::transports::TransportError;
 use alloy_provider::RootProvider;
 use alloy_provider::network::AnyNetwork;
 use revm::database_interface::{DBErrorMarker, DatabaseRef};
@@ -41,25 +42,30 @@ enum GetProofOutcome {
 
 /// Returns `true` only when an error is an explicit JSON-RPC "Method not found"
 /// response (-32601). Transient failures (connection reset, timeout, etc.)
-/// are left to propagate normally.
-fn is_method_not_found<E: std::fmt::Display>(err: &E) -> bool {
-    let s = err.to_string();
-    // JSON-RPC standard code for "Method not found".
-    // All compliant providers embed -32601 in the error response.
-    // Transient errors (IO, timeout, HTTP 5xx) never contain this code.
-    s.contains("-32601")
-        || s.to_lowercase().contains("method not found")
-        || s.to_lowercase().contains("eth_getproof is not supported")
+/// are transport-level errors with no error code, so they always return `false`.
+fn is_method_not_found(err: &TransportError) -> bool {
+    let Some(payload) = err.as_error_resp() else {
+        return false;
+    };
+    if payload.code == -32601 {
+        return true;
+    }
+    // String fallback for non-standard providers that send a recognisable
+    // message with a non-standard code.
+    let msg = payload.message.to_lowercase();
+    msg.contains("method not found") || msg.contains("eth_getproof is not supported")
 }
 
 /// A minimal revm database backed by standard RPC calls.
 ///
-/// `basic_ref` attempts `eth_getProof` + `eth_getCode` concurrently (≤2 RPCs per
-/// account). When the RPC endpoint explicitly rejects `eth_getProof` with a
-/// "method not found" response, the `proof_supported` flag is cleared and all
-/// subsequent calls use concurrent `eth_getBalance` / `eth_getTransactionCount` /
-/// `eth_getCode` via `tokio::join!` (3 RPCs in parallel, not in series). Transient
-/// errors are propagated to the caller and do not affect the fallback state.
+/// `basic_ref` attempts `eth_getProof` + `eth_getCode` concurrently (2 RPCs per
+/// account; for EOAs the code call is redundant but completes in parallel so
+/// there is no latency cost). When the RPC endpoint explicitly rejects
+/// `eth_getProof` with a "method not found" response, the `proof_supported` flag
+/// is cleared and all subsequent calls use concurrent `eth_getBalance` /
+/// `eth_getTransactionCount` / `eth_getCode` via `tokio::join!` (3 RPCs in
+/// parallel, not in series). Transient errors are propagated to the caller and
+/// do not affect the fallback state.
 pub struct SimpleRpcDb {
     pub provider: RootProvider<AnyNetwork>,
     pub block_number: u64,
@@ -154,8 +160,9 @@ impl SimpleRpcDb {
 
     /// Attempt to fetch account metadata via `eth_getProof`.
     ///
-    /// `eth_getProof` and `eth_getCode` are issued concurrently. The code result
-    /// is discarded for EOAs (code_hash == KECCAK_EMPTY).
+    /// `eth_getProof` and `eth_getCode` are issued concurrently (2 RPCs). For
+    /// EOAs (`code_hash == KECCAK_EMPTY`) the code result is discarded; the call
+    /// still completes in parallel so there is no added latency.
     ///
     /// Returns [`GetProofOutcome::MethodNotSupported`] when the RPC responds with
     /// a "method not found" error (-32601). All other errors become
@@ -232,34 +239,48 @@ impl SimpleRpcDb {
 
 #[cfg(test)]
 mod tests {
+    use alloy_json_rpc::ErrorPayload;
+    use alloy_transport::{RpcError, TransportError, TransportErrorKind};
+
     use super::*;
 
-    /// `is_method_not_found` must accept the canonical JSON-RPC -32601 error
-    /// string and common provider-specific variants, while rejecting transient
-    /// failures that should propagate to the caller.
+    fn error_resp(code: i64, message: &'static str) -> TransportError {
+        RpcError::ErrorResp(ErrorPayload {
+            code,
+            message: message.into(),
+            data: None,
+        })
+    }
+
+    /// `is_method_not_found` must accept the canonical JSON-RPC -32601 error and
+    /// common provider-specific message variants, while rejecting transient failures
+    /// and unrelated RPC errors.
     #[test]
     fn test_is_method_not_found_detection() {
-        // Standard alloy error display for -32601
-        assert!(is_method_not_found(
-            &"server returned an error response: error code -32601: Method not found"
-        ));
-        // Short form that some providers emit
-        assert!(is_method_not_found(&"error code -32601: method not found"));
-        // Provider that spells out the method name
-        assert!(is_method_not_found(
-            &"eth_getProof is not supported on this endpoint"
-        ));
-        // Generic "method not found" without an error code
-        assert!(is_method_not_found(&"Method not found"));
+        // Standard -32601 code
+        assert!(is_method_not_found(&error_resp(-32601, "Method not found")));
+        // Provider that sends -32601 with a different capitalisation
+        assert!(is_method_not_found(&error_resp(-32601, "method not found")));
+        // Non-standard code but recognisable message (string fallback)
+        assert!(is_method_not_found(&error_resp(
+            -32000,
+            "eth_getProof is not supported on this endpoint"
+        )));
+        // Non-standard code with generic "method not found" message (string fallback)
+        assert!(is_method_not_found(&error_resp(0, "Method not found")));
 
-        // Transient errors — must NOT trigger fallback
-        assert!(!is_method_not_found(&"connection reset by peer"));
-        assert!(!is_method_not_found(&"request timed out"));
-        assert!(!is_method_not_found(
-            &"server returned an error response: error code -32000: execution reverted"
-        ));
-        assert!(!is_method_not_found(
-            &"server returned an error response: error code -32603: internal error"
-        ));
+        // Transport-level errors (no error code) — must NOT trigger fallback
+        assert!(!is_method_not_found(&TransportErrorKind::custom_str(
+            "connection reset by peer"
+        )));
+        assert!(!is_method_not_found(&TransportErrorKind::custom_str(
+            "request timed out"
+        )));
+        // RPC errors with unrelated codes — must NOT trigger fallback
+        assert!(!is_method_not_found(&error_resp(
+            -32000,
+            "execution reverted"
+        )));
+        assert!(!is_method_not_found(&error_resp(-32603, "internal error")));
     }
 }


### PR DESCRIPTION
## Summary

Closes #136 (partially — storage slot prefetch is tracked separately in #142).

Replaces `SimpleRpcDb::basic_ref`'s 3 sequential RPC calls (`eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`) with a two-tier strategy:

**Primary path — `eth_getProof` (EIP-1186):**
- `eth_getProof` and `eth_getCode` are issued concurrently via `tokio::join!`
- EOAs: 1 RPC total (was 3 sequential)
- Contracts: 2 concurrent RPCs (was 3 sequential)

**Fallback path — parallel calls (fixes #116):**
- Triggered only when the RPC responds with an explicit `-32601` "Method not found" error; transient failures (network timeouts, connection resets) propagate to the caller and do not affect the fallback state
- Once detected as unsupported, an `AtomicBool` skips `eth_getProof` for all subsequent calls in the same `SimpleRpcDb` instance
- `eth_getBalance`, `eth_getTransactionCount`, and `eth_getCode` are issued concurrently via `tokio::join!` — latency drops from 3×RTT to ~1×RTT

Both paths reduce per-account latency from 3 serialised round-trips to approximately 1 round-trip. The proof path additionally cuts the total RPC count by 3×, which matters for provider rate limits and non-HTTP/2 connections.

## Files Changed

- `crates/evmsketch/src/simple_rpc_db.rs` — rewrote `basic_ref`; added `try_fetch_with_proof`, `fetch_account_parallel`, `GetProofOutcome`, `is_method_not_found`, and `SimpleRpcDb::new` constructor
- `crates/evmsketch/src/lib.rs` — updated all `SimpleRpcDb` construction sites to use `::new()`
- `crates/evmsketch/benches/fixtures/generate_replay_fixture.rs` — same constructor update

## Benchmark

CI offline benches show no change (expected — they use pre-populated `CacheDB<EmptyDB>` and never call `basic_ref`). The improvement is only visible in the live RPC path.

Local `end_to_end` bench against the configured QuikNode endpoint (which **does** support `eth_getProof`):

| metric | `main` | this branch | change |
|--------|:-------:|:-----------:|:------:|
| wall time (median) | 2.71 s | 2.57 s | **−5.3%** |
| CI range | — | [2.51 s, 2.68 s] | |

The pinned tx touches few cold accounts so the absolute saving is small. Txs touching many cold accounts (e.g. the 266-account replay in #136) would compound the saving proportionally.