### PR TITLE
Reduce intermediate allocations in trace parsing

### DIFF
--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -21,9 +21,12 @@ pub fn copy_memory(memory: &[u8], offset: usize, length: usize) -> Vec<u8> {
     if memory.len() >= offset + length {
         memory[offset..offset + length].to_vec()
     } else {
-        let mut result = memory.to_vec();
-        result.resize(offset + length, 0);
-        result[offset..offset + length].to_vec()
+        let mut result = vec![0u8; length];
+        if offset < memory.len() {
+            let copy_len = memory.len() - offset;
+            result[..copy_len].copy_from_slice(&memory[offset..]);
+        }
+        result
     }
 }
 
@@ -33,16 +36,18 @@ pub fn copy_memory(memory: &[u8], offset: usize, length: usize) -> Vec<u8> {
 /// memory words after revm-inspectors v0.38.1 (Foundry v1.7.0), while geth/erigon
 /// and older Anvil emit bare hex.
 pub fn parse_trace_memory(memory: Vec<String>) -> Vec<u8> {
-    memory
+    let total_bytes: usize = memory
         .iter()
-        .map(|s| s.strip_prefix("0x").unwrap_or(s))
-        .collect::<String>()
-        .chars()
-        .collect::<Vec<char>>()
-        .chunks(2)
-        .map(|c| c.iter().collect::<String>())
-        .map(|s| u8::from_str_radix(&s, 16).expect("invalid hex"))
-        .collect::<Vec<u8>>()
+        .map(|s| s.strip_prefix("0x").unwrap_or(s).len() / 2)
+        .sum();
+    let mut result = Vec::with_capacity(total_bytes);
+    for s in &memory {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let start = result.len();
+        result.resize(start + s.len() / 2, 0);
+        hex::decode_to_slice(s, &mut result[start..]).expect("invalid hex");
+    }
+    result
 }
 
 // ============================================================================
@@ -169,7 +174,7 @@ pub fn append_state_update_from_struct_log(
 pub fn compute_state_updates(
     trace: DefaultFrame,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>, u64)> {
-    let mut state_updates: Vec<StateUpdate> = Vec::new();
+    let mut state_updates: Vec<StateUpdate> = Vec::with_capacity(trace.struct_logs.len() / 4);
     let mut target_depth = 1u64;
     let mut skipped_opcodes = HashSet::new();
     // Stack of (depth, call_index) for CALLs we're inside. Call index is 1-based for display.

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -18,13 +18,14 @@ use crate::types::{IStateUpdateTypes, Opcode, StateUpdate};
 
 /// Copy memory with bounds checking, zero-padding if needed.
 pub fn copy_memory(memory: &[u8], offset: usize, length: usize) -> Vec<u8> {
-    if memory.len() >= offset + length {
-        memory[offset..offset + length].to_vec()
+    let end = offset.saturating_add(length);
+    if memory.len() >= end {
+        memory[offset..end].to_vec()
     } else {
         let mut result = vec![0u8; length];
         if offset < memory.len() {
-            let copy_len = memory.len() - offset;
-            result[..copy_len].copy_from_slice(&memory[offset..]);
+            let copy_len = (memory.len() - offset).min(length);
+            result[..copy_len].copy_from_slice(&memory[offset..offset + copy_len]);
         }
         result
     }


### PR DESCRIPTION
Closes https://github.com/gas-killer/gas-analyzer/issues/118.

Branched off https://github.com/gas-killer/gas-analyzer/pull/143 so that should be closed first.

## Summary

- `parse_trace_memory`: replaces join → `Vec<char>` → per-byte `String` chain with a single pre-sized allocation + `hex::decode_to_slice` per word — eliminates all intermediate heap objects.
- `copy_memory` else-branch: replaces double-copy (`memory.to_vec()` + `result[..].to_vec()`) with a single `vec![0u8; length]` + `copy_from_slice` of available bytes.
- `compute_state_updates`: adds `Vec::with_capacity(struct_logs.len() / 4)` heuristic to avoid incremental reallocation while scanning the log.

Closes #118.

## Test plan

- [x] `cargo fmt --all && cargo clippy -- -D warnings && cargo check && cargo test -p gas-analyzer-core` pass locally
- [ ] `parse_trace_memory_handles_both_prefixed_and_bare_hex` still passes (bare, prefixed, and mixed inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)