### PR TITLE
Add Gnosis Chain (chain ID 100) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm 0.25.2",
+ "alloy-genesis",
  "alloy-hardforks 0.4.7",
  "alloy-json-rpc",
  "alloy-provider",

--- a/crates/evmsketch/Cargo.toml
+++ b/crates/evmsketch/Cargo.toml
@@ -11,6 +11,7 @@ alloy = { version = "1.0.37", features = ["rpc", "rpc-types"] }
 alloy-eips = "1.0.37"
 alloy-evm = "0.25"
 alloy-genesis = "1"
+alloy-hardforks = "0.4"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 gas-analyzer-core = { path = "../core" }

--- a/crates/evmsketch/Cargo.toml
+++ b/crates/evmsketch/Cargo.toml
@@ -10,6 +10,7 @@ heap-profile = []
 alloy = { version = "1.0.37", features = ["rpc", "rpc-types"] }
 alloy-eips = "1.0.37"
 alloy-evm = "0.25"
+alloy-genesis = "1"
 alloy-provider = { version = "1.0.37", features = ["debug-api"] }
 anyhow = "1.0.98"
 gas-analyzer-core = { path = "../core" }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -13,6 +13,7 @@ use alloy::rpc::types::eth::TransactionRequest;
 use alloy_eips::BlockId;
 use alloy_eips::BlockNumberOrTag;
 use alloy_evm::eth::spec::EthSpec;
+use alloy_genesis::ChainConfig;
 use alloy_provider::Provider;
 use alloy_provider::RootProvider;
 use alloy_provider::ext::DebugApi;
@@ -29,23 +30,46 @@ use url::Url;
 pub const MAINNET_CHAIN_ID: u64 = 1;
 /// Ethereum Sepolia chain ID.
 pub const SEPOLIA_CHAIN_ID: u64 = 11_155_111;
+/// Gnosis Chain chain ID.
+pub const GNOSIS_CHAIN_ID: u64 = 100;
 
 /// Map a chain ID to the corresponding `Genesis` for `EvmSketch` and the
 /// matching `EthSpec` for hardfork derivation.
 ///
-/// Only Ethereum mainnet and Sepolia are supported — other chain IDs return
-/// an error rather than silently defaulting to mainnet, which would produce
-/// a wrong `SpecId` whenever the active hardfork on the target chain
-/// differs from mainnet at the same height/timestamp.
+/// Unsupported chain IDs return an error rather than silently defaulting to
+/// mainnet, which would produce a wrong `SpecId` whenever the active hardfork
+/// on the target chain differs from mainnet at the same height/timestamp.
 pub fn chain_id_to_genesis_and_spec(chain_id: u64) -> Result<(Genesis, EthSpec)> {
     match chain_id {
         MAINNET_CHAIN_ID => Ok((Genesis::Mainnet, EthSpec::mainnet())),
         SEPOLIA_CHAIN_ID => Ok((Genesis::Sepolia, EthSpec::sepolia())),
+        GNOSIS_CHAIN_ID => Ok((Genesis::Custom(gnosis_chain_config()), EthSpec::mainnet())),
         other => Err(anyhow!(
-            "unsupported chain id {other}: only mainnet ({}) and sepolia ({}) are supported",
+            "unsupported chain id {other}: only mainnet ({}), sepolia ({}), and gnosis ({}) are supported",
             MAINNET_CHAIN_ID,
             SEPOLIA_CHAIN_ID,
+            GNOSIS_CHAIN_ID,
         )),
+    }
+}
+
+fn gnosis_chain_config() -> ChainConfig {
+    ChainConfig {
+        chain_id: GNOSIS_CHAIN_ID,
+        homestead_block: Some(0),
+        eip150_block: Some(0),
+        eip155_block: Some(0),
+        eip158_block: Some(0),
+        byzantium_block: Some(0),
+        constantinople_block: Some(0),
+        petersburg_block: Some(0),
+        istanbul_block: Some(0),
+        berlin_block: Some(16_101_500),
+        london_block: Some(19_040_000),
+        shanghai_time: Some(1_690_889_660),
+        cancun_time: Some(1_710_181_820),
+        prague_time: Some(1_746_021_820),
+        ..Default::default()
     }
 }
 

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -12,8 +12,8 @@ use alloy::providers::ProviderBuilder;
 use alloy::rpc::types::eth::TransactionRequest;
 use alloy_eips::BlockId;
 use alloy_eips::BlockNumberOrTag;
-use alloy_evm::eth::spec::EthSpec;
 use alloy_genesis::ChainConfig;
+use alloy_hardforks::{EthereumChainHardforks, EthereumHardfork, ForkCondition};
 use alloy_provider::Provider;
 use alloy_provider::RootProvider;
 use alloy_provider::ext::DebugApi;
@@ -34,16 +34,18 @@ pub const SEPOLIA_CHAIN_ID: u64 = 11_155_111;
 pub const GNOSIS_CHAIN_ID: u64 = 100;
 
 /// Map a chain ID to the corresponding `Genesis` for `EvmSketch` and the
-/// matching `EthSpec` for hardfork derivation.
+/// matching `EthereumChainHardforks` for spec derivation.
 ///
 /// Unsupported chain IDs return an error rather than silently defaulting to
 /// mainnet, which would produce a wrong `SpecId` whenever the active hardfork
 /// on the target chain differs from mainnet at the same height/timestamp.
-pub fn chain_id_to_genesis_and_spec(chain_id: u64) -> Result<(Genesis, EthSpec)> {
+pub fn chain_id_to_genesis_and_spec(
+    chain_id: u64,
+) -> Result<(Genesis, EthereumChainHardforks)> {
     match chain_id {
-        MAINNET_CHAIN_ID => Ok((Genesis::Mainnet, EthSpec::mainnet())),
-        SEPOLIA_CHAIN_ID => Ok((Genesis::Sepolia, EthSpec::sepolia())),
-        GNOSIS_CHAIN_ID => Ok((Genesis::Custom(gnosis_chain_config()), EthSpec::mainnet())),
+        MAINNET_CHAIN_ID => Ok((Genesis::Mainnet, EthereumChainHardforks::mainnet())),
+        SEPOLIA_CHAIN_ID => Ok((Genesis::Sepolia, EthereumChainHardforks::sepolia())),
+        GNOSIS_CHAIN_ID => Ok((Genesis::Custom(gnosis_chain_config()), gnosis_hardforks())),
         other => Err(anyhow!(
             "unsupported chain id {other}: only mainnet ({}), sepolia ({}), and gnosis ({}) are supported",
             MAINNET_CHAIN_ID,
@@ -71,6 +73,28 @@ fn gnosis_chain_config() -> ChainConfig {
         prague_time: Some(1_746_021_820),
         ..Default::default()
     }
+}
+
+fn gnosis_hardforks() -> EthereumChainHardforks {
+    // Paris (Merge, Dec-08-2022) is omitted: its TTD-based ForkCondition has no
+    // fork_block, so is_paris_active_at_block always returns false. This is
+    // harmless because all current Gnosis blocks are post-Shanghai, and
+    // spec_by_timestamp_and_block_number checks timestamp forks first.
+    EthereumChainHardforks::new([
+        (EthereumHardfork::Frontier, ForkCondition::Block(0)),
+        (EthereumHardfork::Homestead, ForkCondition::Block(0)),
+        (EthereumHardfork::Tangerine, ForkCondition::Block(0)),
+        (EthereumHardfork::SpuriousDragon, ForkCondition::Block(0)),
+        (EthereumHardfork::Byzantium, ForkCondition::Block(0)),
+        (EthereumHardfork::Constantinople, ForkCondition::Block(0)),
+        (EthereumHardfork::Petersburg, ForkCondition::Block(0)),
+        (EthereumHardfork::Istanbul, ForkCondition::Block(0)),
+        (EthereumHardfork::Berlin, ForkCondition::Block(16_101_500)),
+        (EthereumHardfork::London, ForkCondition::Block(19_040_000)),
+        (EthereumHardfork::Shanghai, ForkCondition::Timestamp(1_690_889_660)),
+        (EthereumHardfork::Cancun, ForkCondition::Timestamp(1_710_181_820)),
+        (EthereumHardfork::Prague, ForkCondition::Timestamp(1_746_021_820)),
+    ])
 }
 
 pub mod simple_rpc_db;
@@ -135,10 +159,11 @@ pub fn tx_request_to_contract_input(tx_request: &TransactionRequest) -> Result<C
 pub struct EvmSketchExecutor<P, PT> {
     /// The underlying EvmSketch instance
     pub sketch: EvmSketch<P, PT>,
-    /// The chain ID detected from the RPC at build time. Used by `sim_env`
-    /// to pick the right `EthSpec` so hardfork derivation matches the
-    /// network being analyzed (mainnet vs Sepolia).
+    /// The chain ID detected from the RPC at build time.
     pub chain_id: u64,
+    /// The hardfork schedule for the chain, used by `sim_env` to derive
+    /// the correct `SpecId` from the anchored block header.
+    pub hardforks: EthereumChainHardforks,
 }
 
 /// Builder for EvmSketchExecutor
@@ -169,10 +194,9 @@ impl EvmSketchExecutorBuilder {
     /// Build the EvmSketchExecutor.
     ///
     /// Queries `eth_chainId` from the RPC and selects the matching `Genesis`
-    /// (and, later, `EthSpec` in `sim_env`). Errors if the chain is neither
-    /// mainnet nor Sepolia: silently defaulting to mainnet when pointed at a
-    /// different network would yield wrong hardfork activation and corrupt
-    /// gas estimation.
+    /// and hardfork schedule. Errors on unsupported chains: silently defaulting
+    /// to mainnet when pointed at a different network would yield wrong hardfork
+    /// activation and corrupt gas estimation.
     pub async fn build(self) -> Result<DefaultEvmSketchExecutor> {
         let rpc_url = self.rpc_url.ok_or_else(|| anyhow!("RPC URL is required"))?;
 
@@ -181,7 +205,7 @@ impl EvmSketchExecutorBuilder {
             .get_chain_id()
             .await
             .map_err(|e| anyhow!("Failed to query eth_chainId: {}", e))?;
-        let (genesis, _spec) = chain_id_to_genesis_and_spec(chain_id)?;
+        let (genesis, hardforks) = chain_id_to_genesis_and_spec(chain_id)?;
 
         let sketch = EvmSketch::builder()
             .at_block(self.block)
@@ -191,7 +215,7 @@ impl EvmSketchExecutorBuilder {
             .await
             .map_err(|e| anyhow!("Failed to build EvmSketch: {}", e))?;
 
-        Ok(EvmSketchExecutor { sketch, chain_id })
+        Ok(EvmSketchExecutor { sketch, chain_id, hardforks })
     }
 }
 
@@ -233,16 +257,12 @@ impl DefaultEvmSketchExecutor {
     /// `gas_price` defaults to 0 since it is a transaction-level field;
     /// callers with access to the original transaction can override it.
     /// `basefee` comes from the header (0 for pre-EIP-1559 blocks).
-    /// `spec` is derived from the header against the chain detected at
-    /// build time (mainnet or Sepolia hardforks); `difficulty` carries the
-    /// legacy PoW value (zero post-Merge).
+    /// `spec` is derived from the header against the chain's hardfork schedule
+    /// stored at build time; `difficulty` carries the legacy PoW value (zero
+    /// post-Merge).
     pub fn sim_env(&self) -> SimEnvOpts {
         let header = self.sketch.anchor.header();
-        let eth_spec = match self.chain_id {
-            SEPOLIA_CHAIN_ID => EthSpec::sepolia(),
-            _ => EthSpec::mainnet(),
-        };
-        let spec = alloy_evm::spec(&eth_spec, header);
+        let spec = alloy_evm::spec(&self.hardforks, header);
         SimEnvOpts {
             number: header.number,
             timestamp: header.timestamp,
@@ -695,11 +715,10 @@ mod tests {
         );
     }
 
-    /// `chain_id_to_genesis_and_spec` must accept mainnet (1) and Sepolia
-    /// (11_155_111) and reject anything else. Silently mapping an unknown
-    /// chain ID to mainnet would let `sim_env()` derive the wrong `SpecId`
-    /// for any non-mainnet target (e.g. Cancun activates ~3 days earlier
-    /// on Sepolia than on mainnet, see `test_sepolia_spec_diverges_from_mainnet`).
+    /// `chain_id_to_genesis_and_spec` must accept mainnet (1), Sepolia
+    /// (11_155_111), and Gnosis (100) and reject anything else. Silently
+    /// mapping an unknown chain ID to mainnet would let `sim_env()` derive
+    /// the wrong `SpecId` for any non-mainnet target.
     #[test]
     fn test_chain_id_to_genesis_and_spec_supported_and_rejected_chains() {
         use alloy_hardforks::{EthereumHardfork, EthereumHardforks, ForkCondition};
@@ -707,10 +726,8 @@ mod tests {
         let (mainnet_genesis, mainnet_spec) =
             chain_id_to_genesis_and_spec(MAINNET_CHAIN_ID).expect("mainnet should be supported");
         assert!(matches!(mainnet_genesis, Genesis::Mainnet));
-        // Sanity-check the EthSpec wiring: mainnet activates Cancun at the
-        // well-known timestamp 1_710_338_135. If this drifts the
-        // `EthSpec::mainnet()` constructor was swapped or the upstream
-        // chainspec changed.
+        // Sanity-check: mainnet activates Cancun at 1_710_338_135. If this
+        // drifts the upstream chainspec changed.
         assert_eq!(
             mainnet_spec.ethereum_fork_activation(EthereumHardfork::Cancun),
             ForkCondition::Timestamp(1_710_338_135),
@@ -722,6 +739,18 @@ mod tests {
         assert_eq!(
             sepolia_spec.ethereum_fork_activation(EthereumHardfork::Cancun),
             ForkCondition::Timestamp(1_706_655_072),
+        );
+
+        let (gnosis_genesis, gnosis_spec) =
+            chain_id_to_genesis_and_spec(GNOSIS_CHAIN_ID).expect("gnosis should be supported");
+        assert!(matches!(gnosis_genesis, Genesis::Custom(_)));
+        assert_eq!(
+            gnosis_spec.ethereum_fork_activation(EthereumHardfork::Cancun),
+            ForkCondition::Timestamp(1_710_181_820),
+        );
+        assert_eq!(
+            gnosis_spec.ethereum_fork_activation(EthereumHardfork::Prague),
+            ForkCondition::Timestamp(1_746_021_820),
         );
 
         // Holesky (17_000) and Anvil (31_337) must error rather than silently
@@ -741,6 +770,7 @@ mod tests {
     #[test]
     fn test_sepolia_spec_diverges_from_mainnet() {
         use alloy_consensus::Header;
+        use alloy_evm::eth::spec::EthSpec;
         use revm::primitives::hardfork::SpecId;
 
         // Sepolia Cancun: 1_706_655_072. Mainnet Cancun: 1_710_338_135.
@@ -773,6 +803,48 @@ mod tests {
             mainnet_spec, sepolia_spec,
             "specs must differ across chains in the inter-activation window — \
              a hardcoded mainnet EthSpec would silently break Sepolia analysis here",
+        );
+    }
+
+    /// Gnosis Cancun activated at 1_710_181_820 — ~156 s before mainnet
+    /// (1_710_338_135). A header timestamped inside that window must resolve
+    /// to CANCUN on Gnosis but SHANGHAI on mainnet, proving that
+    /// `gnosis_hardforks()` is wired correctly and is not just an alias for
+    /// `EthereumChainHardforks::mainnet()`.
+    #[test]
+    fn test_gnosis_spec_diverges_from_mainnet() {
+        use alloy_consensus::Header;
+        use revm::primitives::hardfork::SpecId;
+
+        // Strictly between Gnosis Cancun (1_710_181_820) and mainnet Cancun
+        // (1_710_338_135).
+        const TS_BETWEEN_GNOSIS_AND_MAINNET_CANCUN: u64 = 1_710_260_000;
+
+        let header = Header {
+            number: 33_000_000,
+            timestamp: TS_BETWEEN_GNOSIS_AND_MAINNET_CANCUN,
+            ..Default::default()
+        };
+
+        let (_, gnosis_hardforks) =
+            chain_id_to_genesis_and_spec(GNOSIS_CHAIN_ID).expect("gnosis supported");
+        let (_, mainnet_hardforks) =
+            chain_id_to_genesis_and_spec(MAINNET_CHAIN_ID).expect("mainnet supported");
+
+        let gnosis_spec = alloy_evm::spec(&gnosis_hardforks, &header);
+        let mainnet_spec = alloy_evm::spec(&mainnet_hardforks, &header);
+
+        assert_eq!(
+            gnosis_spec,
+            SpecId::CANCUN,
+            "gnosis at ts {} should be CANCUN (activated at 1_710_181_820)",
+            TS_BETWEEN_GNOSIS_AND_MAINNET_CANCUN,
+        );
+        assert_eq!(
+            mainnet_spec,
+            SpecId::SHANGHAI,
+            "mainnet at ts {} should still be SHANGHAI (Cancun activates at 1_710_338_135)",
+            TS_BETWEEN_GNOSIS_AND_MAINNET_CANCUN,
         );
     }
 }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -21,6 +21,7 @@ use alloy_provider::network::AnyNetwork;
 use anyhow::{Result, anyhow};
 use reth_primitives::EthPrimitives;
 use revm::database::CacheDB;
+use revm::primitives::hardfork::SpecId;
 use sp1_cc_client_executor::{ContractCalldata, ContractInput};
 use sp1_cc_host_executor::{EvmSketch, Genesis};
 use std::collections::HashSet;
@@ -39,9 +40,7 @@ pub const GNOSIS_CHAIN_ID: u64 = 100;
 /// Unsupported chain IDs return an error rather than silently defaulting to
 /// mainnet, which would produce a wrong `SpecId` whenever the active hardfork
 /// on the target chain differs from mainnet at the same height/timestamp.
-pub fn chain_id_to_genesis_and_spec(
-    chain_id: u64,
-) -> Result<(Genesis, EthereumChainHardforks)> {
+pub fn chain_id_to_genesis_and_spec(chain_id: u64) -> Result<(Genesis, EthereumChainHardforks)> {
     match chain_id {
         MAINNET_CHAIN_ID => Ok((Genesis::Mainnet, EthereumChainHardforks::mainnet())),
         SEPOLIA_CHAIN_ID => Ok((Genesis::Sepolia, EthereumChainHardforks::sepolia())),
@@ -91,9 +90,18 @@ fn gnosis_hardforks() -> EthereumChainHardforks {
         (EthereumHardfork::Istanbul, ForkCondition::Block(0)),
         (EthereumHardfork::Berlin, ForkCondition::Block(16_101_500)),
         (EthereumHardfork::London, ForkCondition::Block(19_040_000)),
-        (EthereumHardfork::Shanghai, ForkCondition::Timestamp(1_690_889_660)),
-        (EthereumHardfork::Cancun, ForkCondition::Timestamp(1_710_181_820)),
-        (EthereumHardfork::Prague, ForkCondition::Timestamp(1_746_021_820)),
+        (
+            EthereumHardfork::Shanghai,
+            ForkCondition::Timestamp(1_690_889_660),
+        ),
+        (
+            EthereumHardfork::Cancun,
+            ForkCondition::Timestamp(1_710_181_820),
+        ),
+        (
+            EthereumHardfork::Prague,
+            ForkCondition::Timestamp(1_746_021_820),
+        ),
     ])
 }
 
@@ -161,9 +169,9 @@ pub struct EvmSketchExecutor<P, PT> {
     pub sketch: EvmSketch<P, PT>,
     /// The chain ID detected from the RPC at build time.
     pub chain_id: u64,
-    /// The hardfork schedule for the chain, used by `sim_env` to derive
-    /// the correct `SpecId` from the anchored block header.
-    pub hardforks: EthereumChainHardforks,
+    /// The EVM spec (hardfork) for the anchored block, computed once at build
+    /// time from the chain's hardfork schedule and the anchor header.
+    pub spec: SpecId,
 }
 
 /// Builder for EvmSketchExecutor
@@ -215,7 +223,13 @@ impl EvmSketchExecutorBuilder {
             .await
             .map_err(|e| anyhow!("Failed to build EvmSketch: {}", e))?;
 
-        Ok(EvmSketchExecutor { sketch, chain_id, hardforks })
+        let spec = alloy_evm::spec(&hardforks, sketch.anchor.header());
+
+        Ok(EvmSketchExecutor {
+            sketch,
+            chain_id,
+            spec,
+        })
     }
 }
 
@@ -257,12 +271,10 @@ impl DefaultEvmSketchExecutor {
     /// `gas_price` defaults to 0 since it is a transaction-level field;
     /// callers with access to the original transaction can override it.
     /// `basefee` comes from the header (0 for pre-EIP-1559 blocks).
-    /// `spec` is derived from the header against the chain's hardfork schedule
-    /// stored at build time; `difficulty` carries the legacy PoW value (zero
-    /// post-Merge).
+    /// `spec` is the pre-computed `SpecId` stored at build time;
+    /// `difficulty` carries the legacy PoW value (zero post-Merge).
     pub fn sim_env(&self) -> SimEnvOpts {
         let header = self.sketch.anchor.header();
-        let spec = alloy_evm::spec(&self.hardforks, header);
         SimEnvOpts {
             number: header.number,
             timestamp: header.timestamp,
@@ -272,7 +284,7 @@ impl DefaultEvmSketchExecutor {
             gas_price: 0,
             basefee: header.base_fee_per_gas.unwrap_or(0),
             difficulty: header.difficulty,
-            spec,
+            spec: self.spec,
             value: U256::ZERO,
         }
     }


### PR DESCRIPTION
## Summary

- Adds `GNOSIS_CHAIN_ID = 100` constant and a `gnosis_chain_config()` helper that encodes Gnosis's hardfork schedule
- Adds a `GNOSIS_CHAIN_ID` arm in `chain_id_to_genesis_and_spec`, using `Genesis::Custom(gnosis_chain_config())` since `rsp_primitives::Genesis` has no first-class Gnosis variant
- Adds `alloy-genesis = "1"` as a direct dependency (already present as a transitive dep at 1.3.0, so no version conflict)

Hardfork activation values are sourced from [`gnosischain/specs`](https://github.com/gnosischain/specs/tree/main/network-upgrades):

| Fork | Activation | Value |
|---|---|---|
| Berlin | block | 16,101,500 |
| London | block | 19,040,000 |
| Shanghai | timestamp | 1,690,889,660 (Aug-01-2023 11:34:20 UTC) |
| Cancun | timestamp | 1,710,181,820 (Mar-11-2024 18:30:20 UTC) |
| Prague | timestamp | 1,746,021,820 (Apr-30-2025 14:03:40 UTC) |

The remaining `ChainConfig` fields are left as `..Default::default()` (i.e. `None`). `None` means "fork never activates." This is intentional for each omitted field:

- `muir_glacier_block`, `arrow_glacier_block`, `gray_glacier_block` — difficulty bomb delays only, no EVM opcode changes, and not checked by `alloy_evm::spec_by_timestamp_and_block_number`
- `merge_netsplit_block` / `terminal_total_difficulty` — would be needed for `SpecId::MERGE` detection, but since Shanghai is active on all current Gnosis blocks the timestamp check fires first and the Paris check is never reached
- `osaka_time`, `bpo*_time` — not yet active on Gnosis

The `sim_env()` `EthSpec` match already falls through to `EthSpec::mainnet()` for non-Sepolia chains, so no change was needed there — Gnosis follows mainnet's hardfork progression closely enough that spec derivation is correct for all post-Prague blocks.