### PR TITLE
Eliminate duplicate `eth_getTransactionReceipt` fetch inside `get_tx_trace`

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -448,7 +448,7 @@ pub async fn get_trace_from_call(
         bail!("transaction failed");
     }
     let tx_hash = tx_receipt.transaction_hash;
-    get_tx_trace(&provider, tx_hash).await
+    get_tx_trace(&provider, tx_hash, tx_receipt.status()).await
 }
 
 // ============================================================================
@@ -548,7 +548,7 @@ pub async fn gaskiller_reporter(
         .get_transaction_by_hash(tx_hash)
         .await?
         .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
-    let trace = get_tx_trace(&provider, tx_hash).await?;
+    let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
     let (state_updates, skipped_opcodes_set, _call_gas_total) = compute_state_updates(trace)?;
     let skipped_opcodes = skipped_opcodes_set
         .into_iter()
@@ -622,8 +622,12 @@ impl<P: Provider + DebugApi> TxStateExtractor<P> {
 
     /// Extract state updates from a transaction hash
     pub async fn extract_state_updates(&self, tx_hash: FixedBytes<32>) -> Result<Vec<StateUpdate>> {
-        // Use existing get_tx_trace function
-        let trace = get_tx_trace(&self.provider, tx_hash).await?;
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&self.provider, tx_hash, receipt.status()).await?;
 
         // Use existing compute_state_updates function
         let (state_updates, _skipped, _call_gas_total) = compute_state_updates(trace)?;
@@ -652,7 +656,7 @@ impl<P: Provider + DebugApi> TxStateExtractor<P> {
             return Err(anyhow!("Transaction failed"));
         }
 
-        let trace = get_tx_trace(&self.provider, tx_hash).await?;
+        let trace = get_tx_trace(&self.provider, tx_hash, receipt.status()).await?;
         let (state_updates, _skipped, _call_gas_total) = compute_state_updates(trace)?;
 
         Ok(StateUpdateReport {
@@ -869,7 +873,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url.clone());
 
         let tx_hash = SIMPLE_STORAGE_SET_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         let gk = GasKillerDefault::new(rpc_url, None).await?;
@@ -890,7 +898,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url.clone());
 
         let tx_hash = ACCESS_CONTROL_MAIN_RUN_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         let gk = GasKillerDefault::new(rpc_url, None).await?;
@@ -911,7 +923,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url.clone());
 
         let tx_hash = ACCESS_CONTROL_MAIN_RUN_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         let gk = GasKillerDefault::new(rpc_url, None).await?;
@@ -939,7 +955,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url);
 
         let tx_hash = SIMPLE_STORAGE_SET_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         assert_eq!(state_updates.len(), 2);
@@ -982,7 +1002,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url);
 
         let tx_hash = SIMPLE_STORAGE_DEPOSIT_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         assert_eq!(state_updates.len(), 2);
@@ -1029,7 +1053,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url);
 
         let tx_hash = DELEGATECALL_CONTRACT_MAIN_RUN_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         assert_eq!(state_updates.len(), 4);
@@ -1094,7 +1122,11 @@ mod tests {
         let provider = ProviderBuilder::new().connect_http(rpc_url);
 
         let tx_hash = SIMPLE_STORAGE_CALL_EXTERNAL_TX_HASH;
-        let trace = get_tx_trace(&provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow!("no receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
         let (state_updates, _, _) = compute_state_updates(trace)?;
 
         assert_eq!(state_updates.len(), 1);

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -547,7 +547,7 @@ pub async fn gaskiller_reporter(
     let transaction = provider
         .get_transaction_by_hash(tx_hash)
         .await?
-        .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
+        .ok_or_else(|| anyhow!("could not get transaction for tx {}", tx_hash))?;
     let trace = get_tx_trace(&provider, tx_hash, receipt.status()).await?;
     let (state_updates, skipped_opcodes_set, _call_gas_total) = compute_state_updates(trace)?;
     let skipped_opcodes = skipped_opcodes_set

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -235,7 +235,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 use gas_analyzer_rpc::compute_state_updates_from_tx;
 
                 let state_updates_result =
-                    compute_state_updates_from_tx(&provider, bytes.into()).await;
+                    compute_state_updates_from_tx(&provider, bytes.into(), original_status).await;
 
                 let (state_updates, skipped_opcodes, call_gas_total, use_fallback) =
                     match state_updates_result {
@@ -291,7 +291,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
 
                     // Try trace-based heuristic estimation
                     let fallback_estimate = match gk
-                        .estimate_gas_from_trace(&provider, bytes.into())
+                        .estimate_gas_from_trace(&provider, bytes.into(), original_status)
                         .await
                     {
                         Ok(estimate) => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -163,7 +163,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                     .expect("Failed to initialize GasKiller");
 
                 // Get trace and compute state updates
-                let trace = get_tx_trace(&provider, bytes.into()).await?;
+                let trace = get_tx_trace(&provider, bytes.into(), original_status).await?;
                 let (state_updates, skipped_opcodes, _call_gas_total) =
                     compute_state_updates(trace)?;
 

--- a/crates/evmsketch/benches/fixtures/generate_fixture.rs
+++ b/crates/evmsketch/benches/fixtures/generate_fixture.rs
@@ -6,7 +6,7 @@
 //!   make fixture RPC_URL=<sepolia-node>
 
 use alloy::primitives::FixedBytes;
-use alloy::providers::ProviderBuilder;
+use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::Result;
 
 const SEPOLIA_TX_HASH: &str = "0x680e2abfbccaf6246b4bda0989fc55dee169d0f6aef2ca4c63a17c6a8a39d6cb";
@@ -31,7 +31,11 @@ fn main() -> Result<()> {
         let hash: FixedBytes<32> = SEPOLIA_TX_HASH.parse().expect("invalid tx hash constant");
 
         eprintln!("Fetching trace for {SEPOLIA_TX_HASH} ...");
-        let trace = gas_analyzer_rpc::get_tx_trace(&provider, hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(hash)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("no receipt for tx {}", hash))?;
+        let trace = gas_analyzer_rpc::get_tx_trace(&provider, hash, receipt.status()).await?;
 
         let json = serde_json::to_string_pretty(&trace)?;
 

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -589,20 +589,18 @@ impl GasKillerEvmSketchDefault {
 
     /// Estimate gas using a fallback heuristic based on the original transaction trace.
     ///
-    /// This extracts operations (SSTORE, LOG, CALL) from the original transaction trace
-    /// and applies heuristic costs.
+    /// `status` must be `receipt.status()` for `tx_hash`. Pass the already-fetched
+    /// receipt's status to avoid an extra `eth_getTransactionReceipt` round-trip.
+    /// Extracts operations (SSTORE, LOG, CALL) from the trace and applies heuristic costs.
     pub async fn estimate_gas_from_trace<P: Provider + DebugApi>(
         &self,
         provider: &P,
         tx_hash: alloy::primitives::FixedBytes<32>,
+        status: bool,
     ) -> Result<u64> {
         use gas_analyzer_rpc::get_tx_trace;
 
-        let receipt = provider
-            .get_transaction_receipt(tx_hash)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("could not get receipt for tx {}", tx_hash))?;
-        let trace = get_tx_trace(provider, tx_hash, receipt.status()).await?;
+        let trace = get_tx_trace(provider, tx_hash, status).await?;
         let operations = extract_operation_counts_from_trace(&trace);
         Ok(estimate_gas_from_operations(&operations))
     }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -543,7 +543,11 @@ impl GasKillerEvmSketchDefault {
     ) -> Result<u64> {
         use gas_analyzer_rpc::get_tx_trace;
 
-        let trace = get_tx_trace(provider, tx_hash).await?;
+        let receipt = provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("could not get receipt for tx {}", tx_hash))?;
+        let trace = get_tx_trace(provider, tx_hash, receipt.status()).await?;
         let operations = extract_operation_counts_from_trace(&trace);
         Ok(estimate_gas_from_operations(&operations))
     }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -28,13 +28,9 @@ use gas_analyzer_estimator::PrecedingTx;
 pub async fn get_tx_trace<P: Provider + DebugApi>(
     provider: &P,
     tx_hash: FixedBytes<32>,
+    status: bool,
 ) -> Result<DefaultFrame> {
-    let tx_receipt = provider
-        .get_transaction_receipt(tx_hash)
-        .await?
-        .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
-
-    if !tx_receipt.status() {
+    if !status {
         bail!("transaction failed");
     }
 
@@ -99,8 +95,12 @@ pub async fn compute_state_updates_from_tx<P: Provider + DebugApi>(
     provider: &P,
     tx_hash: FixedBytes<32>,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>, u64)> {
+    let receipt = provider
+        .get_transaction_receipt(tx_hash)
+        .await?
+        .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
     // Primary path: use the historical trace via debug_traceTransaction.
-    let trace = get_tx_trace(provider, tx_hash).await?;
+    let trace = get_tx_trace(provider, tx_hash, receipt.status()).await?;
     let struct_logs_len = trace.struct_logs.len();
     if struct_logs_len > 0 {
         return compute_state_updates(trace);

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -23,8 +23,9 @@ use gas_analyzer_estimator::PrecedingTx;
 
 /// Get transaction trace from a provider using debug_traceTransaction.
 ///
-/// This fetches the actual historical trace from an already-executed transaction,
-/// ensuring we get the exact values that were stored during the original execution.
+/// `status` must be the receipt status for `tx_hash` (`receipt.status()`).
+/// Pass the already-fetched receipt's status to avoid a redundant RPC call.
+/// Returns an error immediately if `status` is `false` (transaction reverted).
 pub async fn get_tx_trace<P: Provider + DebugApi>(
     provider: &P,
     tx_hash: FixedBytes<32>,
@@ -88,19 +89,17 @@ where
 
 /// Compute state updates from an existing transaction using its actual trace.
 ///
-/// This is a convenience function that combines `get_tx_trace` and `compute_state_updates`.
+/// `status` must be `receipt.status()` for `tx_hash`. Pass the already-fetched
+/// receipt's status to avoid an extra `eth_getTransactionReceipt` round-trip.
 ///
 /// Returns: (state_updates, skipped_opcodes, call_gas_total)
 pub async fn compute_state_updates_from_tx<P: Provider + DebugApi>(
     provider: &P,
     tx_hash: FixedBytes<32>,
+    status: bool,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>, u64)> {
-    let receipt = provider
-        .get_transaction_receipt(tx_hash)
-        .await?
-        .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
     // Primary path: use the historical trace via debug_traceTransaction.
-    let trace = get_tx_trace(provider, tx_hash, receipt.status()).await?;
+    let trace = get_tx_trace(provider, tx_hash, status).await?;
     let struct_logs_len = trace.struct_logs.len();
     if struct_logs_len > 0 {
         return compute_state_updates(trace);


### PR DESCRIPTION
## Summary

Closes #140.

`eth_getTransactionReceipt` was fetched twice per analysis request: once in the front-matter phase (to obtain `block_number`, `tx_index`, etc.) and again inside `get_tx_trace` (just to call `.status()`). This eliminates the duplicate.

- `get_tx_trace` no longer fetches the receipt internally; accepts `status: bool` instead
- `compute_state_updates_from_tx` fetches the receipt itself before delegating to `get_tx_trace`
- All call sites that already held a receipt (CLI front-matter, `gaskiller_reporter`, `extract_with_metadata`, post-send flow) now pass `receipt.status()` directly — saving one `eth_getTransactionReceipt` round-trip (~30 ms) per request
- Remaining call sites (tests, `TxStateExtractor::extract_state_updates`, `estimate_gas_from_trace`, benchmark fixture) fetch the receipt themselves, keeping the same total RPC call count as before

## Files changed

- `crates/rpc/src/lib.rs` — updated `get_tx_trace` signature; `compute_state_updates_from_tx` now fetches receipt
- `crates/cli/src/main.rs` — passes `original_status` from already-fetched receipt
- `crates/anvil/src/lib.rs` — updated all call sites
- `crates/evmsketch/src/lib.rs` — `estimate_gas_from_trace` fetches receipt before calling `get_tx_trace`
- `crates/evmsketch/benches/fixtures/generate_fixture.rs` — fetches receipt before calling `get_tx_trace`