### PR TITLE
Prefetch storage slots via `eth_getProof` using EIP-2930 access list

### DIFF
--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -18,14 +18,14 @@ use alloy_provider::Provider;
 use alloy_provider::RootProvider;
 use alloy_provider::ext::DebugApi;
 use alloy_provider::network::AnyNetwork;
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use lru::LruCache;
 use reth_primitives::EthPrimitives;
 use revm::database::CacheDB;
 use revm::primitives::hardfork::SpecId;
 use sp1_cc_client_executor::{ContractCalldata, ContractInput};
 use sp1_cc_host_executor::{EvmSketch, Genesis};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use url::Url;
@@ -109,7 +109,7 @@ fn gnosis_hardforks() -> EthereumChainHardforks {
 }
 
 pub mod simple_rpc_db;
-use simple_rpc_db::SimpleRpcDb;
+use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 
 use gas_analyzer_core::{
     Opcode, StateUpdate, compute_state_updates, encode_state_updates_to_abi,
@@ -361,6 +361,44 @@ impl DefaultEvmSketchExecutor {
         )
     }
 
+    /// Estimate gas for a set of state updates, prefetching storage slots first.
+    ///
+    /// Like `estimate_state_changes_gas` but accepts a map of `address →
+    /// storage keys` sourced from the transaction's EIP-2930 access list (or
+    /// any other prior knowledge). Before EVM execution begins, each address
+    /// in `storage_hints` is fetched via a single `eth_getProof` call that
+    /// returns both account metadata and the listed slot values, eliminating
+    /// the per-slot `eth_getStorageAt` round-trips for those keys.
+    ///
+    /// Cold-miss slots not present in `storage_hints` still fall back to
+    /// `eth_getStorageAt` during execution — an incomplete hint set is safe.
+    pub async fn estimate_state_changes_gas_with_hints(
+        &self,
+        contract_address: Address,
+        caller_address: Address,
+        state_updates: &[gas_analyzer_core::StateUpdate],
+        storage_hints: &HashMap<Address, Vec<B256>>,
+    ) -> Result<u64> {
+        let state_block = self.anchor_block_number().saturating_sub(1);
+        let simple_db = SimpleRpcDb::new(self.sketch.provider.clone(), state_block);
+        let mut cache_db = CacheDB::new(simple_db);
+
+        if !storage_hints.is_empty() {
+            prefetch_slots_into_cache(&mut cache_db, storage_hints)
+                .await
+                .context("storage slot prefetch failed")?;
+        }
+
+        let sim_env = self.sim_env();
+        gas_analyzer_estimator::estimate_state_changes_gas(
+            &mut cache_db,
+            contract_address,
+            caller_address,
+            state_updates,
+            &sim_env,
+        )
+    }
+
     /// Build a `SimEnv` from the anchored block header.
     ///
     /// `gas_price` defaults to 0 since it is a transaction-level field;
@@ -523,6 +561,28 @@ impl GasKillerEvmSketchDefault {
         let mut sim_env = self.executor.sim_env();
 
         if !preceding_txs.is_empty() {
+            // Prefetch storage slots declared in preceding-tx access lists so
+            // that replay_preceding_transactions reads from the in-process cache
+            // instead of issuing per-slot eth_getStorageAt calls.
+            let mut hints: HashMap<Address, Vec<B256>> = HashMap::new();
+            for tx in preceding_txs {
+                for item in tx.access_list.iter() {
+                    hints
+                        .entry(item.address)
+                        .or_default()
+                        .extend(item.storage_keys.iter().copied());
+                }
+            }
+
+            if !hints.is_empty() {
+                let handle = tokio::runtime::Handle::try_current()
+                    .context("no tokio runtime for storage prefetch")?;
+                tokio::task::block_in_place(|| {
+                    handle.block_on(prefetch_slots_into_cache(&mut cache_db, &hints))
+                })
+                .context("prefetch storage slots for preceding txs")?;
+            }
+
             gas_analyzer_estimator::replay_preceding_transactions(
                 &mut cache_db,
                 preceding_txs,
@@ -602,6 +662,20 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
 
     let caller_address = tx_request.from.unwrap_or_default();
 
+    // Collect storage hints from the EIP-2930 access list before tx_request
+    // is consumed by get_trace_from_call. These are passed to the estimator so
+    // that each hinted slot is fetched via a single eth_getProof call rather
+    // than an individual eth_getStorageAt during EVM execution.
+    let mut storage_hints: HashMap<Address, Vec<B256>> = HashMap::new();
+    if let Some(al) = &tx_request.access_list {
+        for item in al.iter() {
+            storage_hints
+                .entry(item.address)
+                .or_default()
+                .extend(item.storage_keys.iter().copied());
+        }
+    }
+
     let provider = ProviderBuilder::new().connect_http(url);
     let block_id = BlockId::Number(BlockNumberOrTag::Number(block_number));
     let trace = get_trace_from_call(&provider, tx_request, block_id).await?;
@@ -611,8 +685,18 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
     let storage_updates = encode_state_updates_to_abi(&state_updates);
 
     let executor = cache.get_or_build(rpc_url, block_number).await?;
-    let gas_estimate =
-        executor.estimate_state_changes_gas(contract_address, caller_address, &state_updates)?;
+    let gas_estimate = if storage_hints.is_empty() {
+        executor.estimate_state_changes_gas(contract_address, caller_address, &state_updates)?
+    } else {
+        executor
+            .estimate_state_changes_gas_with_hints(
+                contract_address,
+                caller_address,
+                &state_updates,
+                &storage_hints,
+            )
+            .await?
+    };
 
     Ok((storage_updates, gas_estimate, false, skipped_opcodes))
 }

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -242,10 +242,16 @@ impl SimpleRpcDb {
 
 /// Prefetch accounts and storage slots into `cache_db` via `eth_getProof`.
 ///
-/// For each `(address, keys)` entry, a single `eth_getProof` request fetches
-/// account metadata and the listed storage values in one round-trip, replacing
-/// K per-slot `eth_getStorageAt` calls with a single call that returns all K
-/// values alongside the account's balance/nonce/code-hash.
+/// For each `(address, keys)` entry, `eth_getProof` and `eth_getCode` are
+/// issued concurrently via `tokio::join!`: the proof call returns account
+/// metadata and all listed storage values; the code call covers contract
+/// accounts (`code_hash != KECCAK_EMPTY`) and is joined in parallel to avoid
+/// a sequential second round-trip. For EOAs the code response is discarded.
+/// This replaces K per-slot `eth_getStorageAt` calls per address with two
+/// concurrent RPC calls regardless of K.
+///
+/// Duplicate keys within an address entry are deduplicated before the call
+/// to avoid inflating the proof payload.
 ///
 /// The results are inserted into `cache_db` so that EVM execution reads them
 /// from the in-process cache without any further RPC calls. Cold-miss slots
@@ -280,8 +286,13 @@ pub async fn prefetch_slots_into_cache(
         let provider = cache_db.db.provider.clone();
         let block = cache_db.db.block_number;
 
+        let unique_keys: Vec<B256> = {
+            let mut seen = std::collections::HashSet::new();
+            keys.iter().copied().filter(|k| seen.insert(*k)).collect()
+        };
+
         let (proof_res, code_res) = tokio::join!(
-            provider.get_proof(*address, keys.clone()).number(block),
+            provider.get_proof(*address, unique_keys).number(block),
             provider.get_code_at(*address).number(block),
         );
 

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use alloy::primitives::{Address, B256, Bytes, U256};
@@ -5,6 +6,8 @@ use alloy::providers::Provider;
 use alloy::transports::TransportError;
 use alloy_provider::RootProvider;
 use alloy_provider::network::AnyNetwork;
+use anyhow::Context as _;
+use revm::database::CacheDB;
 use revm::database_interface::{DBErrorMarker, DatabaseRef};
 use revm::primitives::KECCAK_EMPTY;
 use revm::state::{AccountInfo, Bytecode};
@@ -237,12 +240,240 @@ impl SimpleRpcDb {
     }
 }
 
+/// Prefetch accounts and storage slots into `cache_db` via `eth_getProof`.
+///
+/// For each `(address, keys)` entry, a single `eth_getProof` request fetches
+/// account metadata and the listed storage values in one round-trip, replacing
+/// K per-slot `eth_getStorageAt` calls with a single call that returns all K
+/// values alongside the account's balance/nonce/code-hash.
+///
+/// The results are inserted into `cache_db` so that EVM execution reads them
+/// from the in-process cache without any further RPC calls. Cold-miss slots
+/// (accessed during execution but not present in `slots`) still fall back to
+/// individual `eth_getStorageAt` calls via `storage_ref`, so an incomplete
+/// hint set is safe.
+///
+/// If `eth_getProof` is not supported by the endpoint the `proof_supported`
+/// flag on the underlying `SimpleRpcDb` is cleared (matching the behaviour of
+/// `basic_ref`) and all remaining addresses are skipped — their storage slots
+/// will be fetched on demand.
+#[tracing::instrument(
+    name = "evmsketch.rpc.prefetch",
+    skip(cache_db, slots),
+    level = "debug",
+    fields(address_count = slots.len())
+)]
+pub async fn prefetch_slots_into_cache(
+    cache_db: &mut CacheDB<SimpleRpcDb>,
+    slots: &HashMap<Address, Vec<B256>>,
+) -> anyhow::Result<()> {
+    for (address, keys) in slots {
+        if keys.is_empty() {
+            continue;
+        }
+        if !cache_db.db.proof_supported.load(Ordering::Relaxed) {
+            // eth_getProof was already rejected; remaining slots fall back to
+            // on-demand eth_getStorageAt during EVM execution.
+            break;
+        }
+
+        let provider = cache_db.db.provider.clone();
+        let block = cache_db.db.block_number;
+
+        let (proof_res, code_res) = tokio::join!(
+            provider.get_proof(*address, keys.clone()).number(block),
+            provider.get_code_at(*address).number(block),
+        );
+
+        let proof = match proof_res {
+            Ok(p) => p,
+            Err(e) if is_method_not_found(&e) => {
+                cache_db.db.proof_supported.store(false, Ordering::Relaxed);
+                tracing::debug!(
+                    address = %address,
+                    "eth_getProof unsupported during prefetch; \
+                     storage slots will be fetched on demand"
+                );
+                break;
+            }
+            Err(e) => return Err(anyhow::anyhow!("get_proof failed for {address}: {e}")),
+        };
+
+        let bytecode = if proof.code_hash != KECCAK_EMPTY {
+            match code_res {
+                Ok(b) => Bytecode::new_raw(b),
+                Err(e) => return Err(anyhow::anyhow!("get_code_at failed for {address}: {e}")),
+            }
+        } else {
+            Bytecode::new_raw(Bytes::new())
+        };
+
+        cache_db.insert_account_info(
+            *address,
+            AccountInfo {
+                balance: proof.balance,
+                nonce: proof.nonce,
+                code_hash: proof.code_hash,
+                code: Some(bytecode),
+            },
+        );
+
+        for sp in &proof.storage_proof {
+            let slot = U256::from_be_bytes(sp.key.as_b256().0);
+            cache_db
+                .insert_account_storage(*address, slot, sp.value)
+                .with_context(|| format!("insert_account_storage {address}[{slot}]"))?;
+        }
+
+        tracing::debug!(
+            address = %address,
+            slot_count = proof.storage_proof.len(),
+            "prefetched account and storage via eth_getProof",
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_json_rpc::ErrorPayload;
     use alloy_transport::{RpcError, TransportError, TransportErrorKind};
 
     use super::*;
+
+    /// After `prefetch_slots_into_cache`, the declared slot must be present in
+    /// the CacheDB's in-process storage map, and the account info must reflect
+    /// the values from the proof — all without any `eth_getStorageAt` call.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_prefetch_inserts_proof_storage() {
+        use alloy_provider::RootProvider;
+        use alloy_provider::network::AnyNetwork;
+        use alloy_rpc_client::RpcClient;
+        use alloy_transport::mock::{Asserter, MockTransport};
+        use revm::primitives::U256;
+        use std::collections::HashMap;
+
+        use alloy::primitives::address;
+
+        let addr = address!("0000000000000000000000000000000000001234");
+        let slot_key = U256::from(5u64);
+        let expected_value = U256::from(0x2au64);
+
+        let asserter = Asserter::new();
+
+        // eth_getProof response: EOA with slot 5 = 0x2a
+        asserter.push_success(&serde_json::json!({
+            "address": format!("{addr:#x}"),
+            "balance": "0x0",
+            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "nonce": "0x0",
+            "storageHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "accountProof": [],
+            "storageProof": [{
+                "key": format!("{:#066x}", slot_key),
+                "value": format!("{:#x}", expected_value),
+                "proof": []
+            }]
+        }));
+        // eth_getCode fires concurrently via tokio::join!; KECCAK_EMPTY account
+        // means the result is discarded, but the request still consumes a slot.
+        asserter.push_success(&"0x");
+
+        let transport = MockTransport::new(asserter.clone());
+        let client = RpcClient::new(transport, true);
+        let provider: RootProvider<AnyNetwork> = RootProvider::new(client);
+
+        let db = SimpleRpcDb::new(provider, 42);
+        let mut cache_db = CacheDB::new(db);
+
+        let mut hints = HashMap::new();
+        hints.insert(addr, vec![B256::from(slot_key)]);
+
+        prefetch_slots_into_cache(&mut cache_db, &hints)
+            .await
+            .expect("prefetch should succeed");
+
+        // Verify the slot is now in the CacheDB (no RPC call needed to serve it).
+        let cached = cache_db
+            .cache
+            .accounts
+            .get(&addr)
+            .and_then(|acc| acc.storage.get(&slot_key))
+            .copied();
+        assert_eq!(
+            cached,
+            Some(expected_value),
+            "slot 5 should be in the cache with value 0x2a"
+        );
+
+        // Both responses should have been consumed and no extras remain.
+        assert!(
+            asserter.pop_response().is_none(),
+            "unexpected extra RPC call after prefetch"
+        );
+    }
+
+    /// When `eth_getProof` returns a "method not found" error, prefetch must
+    /// clear `proof_supported`, return `Ok(())`, and leave storage empty so
+    /// cold-miss slots fall back to `eth_getStorageAt` during EVM execution.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_prefetch_skips_on_unsupported_method() {
+        use alloy_json_rpc::ErrorPayload;
+        use alloy_provider::RootProvider;
+        use alloy_provider::network::AnyNetwork;
+        use alloy_rpc_client::RpcClient;
+        use alloy_transport::mock::{Asserter, MockTransport};
+        use revm::primitives::U256;
+        use std::collections::HashMap;
+
+        use alloy::primitives::address;
+
+        let addr = address!("0000000000000000000000000000000000005678");
+
+        let asserter = Asserter::new();
+        // eth_getProof is unsupported — the classic JSON-RPC "method not found"
+        asserter.push_failure(ErrorPayload {
+            code: -32601,
+            message: "Method not found".into(),
+            data: None,
+        });
+        // eth_getCode also fires via tokio::join! and must be consumed.
+        asserter.push_success(&"0x");
+
+        let transport = MockTransport::new(asserter.clone());
+        let client = RpcClient::new(transport, true);
+        let provider: RootProvider<AnyNetwork> = RootProvider::new(client);
+
+        let db = SimpleRpcDb::new(provider, 42);
+        let mut cache_db = CacheDB::new(db);
+
+        let mut hints = HashMap::new();
+        hints.insert(addr, vec![B256::from(U256::from(7u64))]);
+
+        // prefetch must succeed (not propagate the -32601 error)
+        prefetch_slots_into_cache(&mut cache_db, &hints)
+            .await
+            .expect("prefetch must return Ok on unsupported method");
+
+        // proof_supported must be cleared so subsequent basic_ref calls skip eth_getProof
+        assert!(
+            !cache_db.db.proof_supported.load(Ordering::Relaxed),
+            "proof_supported must be cleared after -32601 response"
+        );
+
+        // No storage must be in the cache — cold-miss slots will be fetched
+        // individually by eth_getStorageAt via storage_ref during EVM execution.
+        let cached = cache_db
+            .cache
+            .accounts
+            .get(&addr)
+            .and_then(|acc| acc.storage.get(&U256::from(7u64)))
+            .copied();
+        assert_eq!(
+            cached, None,
+            "slot must not be in cache when proof is unsupported"
+        );
+    }
 
     fn error_resp(code: i64, message: &'static str) -> TransportError {
         RpcError::ErrorResp(ErrorPayload {


### PR DESCRIPTION
Closes #142

## Summary

- Adds `prefetch_slots_into_cache`, a new async function in `simple_rpc_db.rs` that, for each `(address, storage_keys)` pair, issues a single `eth_getProof` call fetching account metadata *and* all listed slot values in one round-trip — replacing K individual `eth_getStorageAt` calls per account
- Adds `estimate_state_changes_gas_with_hints` on `DefaultEvmSketchExecutor` that accepts a `HashMap<Address, Vec<B256>>` of storage hints and runs the prefetch step before `transact()`
- Threads EIP-2930 access list slots through `call_to_encoded_state_updates_with_evmsketch` so that hinted slots are prefetched when an access list is present, falling back to the non-hinted path when it is not
- Prefetches access list slots for preceding transactions in `GasKillerEvmSketchDefault`, using `block_in_place` to drive the async prefetch from the sync replay path
- Cold-miss slots not present in the access list still fall back to `eth_getStorageAt` during execution; an incomplete or absent hint set is always safe
- If the endpoint does not support `eth_getProof`, the `proof_supported` flag on `SimpleRpcDb` is cleared and remaining addresses are skipped silently

## Test plan

- [ ] Run existing test suite: `cargo test -p evmsketch`
- [ ] Verify a tx with an EIP-2930 access list triggers `eth_getProof` rather than per-slot `eth_getStorageAt` (check RPC call counts in logs)
- [ ] Verify a tx with no access list still completes without error (non-hinted fallback path)
- [ ] Verify a cold-miss slot not in the access list is fetched on-demand without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)