### PR TITLE
Batch-prefetch state update slots and call targets before revm execution

### DIFF
--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -471,11 +471,9 @@ impl DefaultEvmSketchExecutor {
         let simple_db = SimpleRpcDb::new(self.sketch.provider.clone(), state_block);
         let mut cache_db = CacheDB::new(simple_db);
 
-        if !storage_hints.is_empty() {
-            prefetch_slots_into_cache(&mut cache_db, storage_hints)
-                .await
-                .context("storage slot prefetch failed")?;
-        }
+        prefetch_slots_into_cache(&mut cache_db, storage_hints)
+            .await
+            .context("storage slot prefetch failed")?;
 
         let sim_env = self.sim_env();
         gas_analyzer_estimator::estimate_state_changes_gas(
@@ -723,6 +721,33 @@ impl GasKillerEvmSketchDefault {
 // call_to_encoded_state_updates_with_evmsketch
 // ============================================================================
 
+/// Derive prefetch hints from a set of state updates.
+///
+/// - `Store`: the slot is at `contract_address`; batching all slots into one
+///   `eth_getProof` call returns every value in a single round-trip.
+/// - `Call`: the target address will be loaded by revm; an empty key list
+///   prefetches just account info (balance/nonce/code), eliminating one
+///   blocking `basic_ref` call during gas estimation.
+/// - `Log*`: carry no addressable state and produce no hints.
+fn hints_from_state_updates(
+    contract_address: Address,
+    state_updates: &[StateUpdate],
+) -> HashMap<Address, Vec<B256>> {
+    let mut hints: HashMap<Address, Vec<B256>> = HashMap::new();
+    for update in state_updates {
+        match update {
+            StateUpdate::Store(s) => {
+                hints.entry(contract_address).or_default().push(s.slot);
+            }
+            StateUpdate::Call(c) => {
+                hints.entry(c.target).or_default();
+            }
+            _ => {}
+        }
+    }
+    hints
+}
+
 /// Compute encoded state updates and gas estimate for a transaction call using EvmSketch.
 ///
 /// Simulates the call via `debug_traceCall` at the given block, extracts state updates,
@@ -784,18 +809,22 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
 
     let storage_updates = encode_state_updates_to_abi(&state_updates);
 
-    let gas_estimate = if storage_hints.is_empty() {
-        executor.estimate_state_changes_gas(contract_address, caller_address, &state_updates)?
-    } else {
-        executor
-            .estimate_state_changes_gas_with_hints(
-                contract_address,
-                caller_address,
-                &state_updates,
-                &storage_hints,
-            )
-            .await?
-    };
+    // Merge access-list hints with slots derived from state_updates.
+    // Store slots all land at contract_address (one eth_getProof call for all of them).
+    // Call targets get account-info-only prefetch (empty key list).
+    let mut all_hints = hints_from_state_updates(contract_address, &state_updates);
+    for (addr, slots) in storage_hints {
+        all_hints.entry(addr).or_default().extend(slots);
+    }
+
+    let gas_estimate = executor
+        .estimate_state_changes_gas_with_hints(
+            contract_address,
+            caller_address,
+            &state_updates,
+            &all_hints,
+        )
+        .await?;
 
     Ok((storage_updates, gas_estimate, false, skipped_opcodes))
 }
@@ -809,6 +838,7 @@ mod tests {
     use super::*;
     use alloy::primitives::{address, bytes};
     use alloy::providers::ProviderBuilder;
+    use gas_analyzer_core::types::IStateUpdateTypes;
 
     /// `with_chain_id` must store the supplied value so `build` can bypass the
     /// `eth_chainId` probe.
@@ -1232,5 +1262,45 @@ mod tests {
             "mainnet at ts {} should still be SHANGHAI (Cancun activates at 1_710_338_135)",
             TS_BETWEEN_GNOSIS_AND_MAINNET_CANCUN,
         );
+    }
+
+    /// `hints_from_state_updates` must map Store slots to contract_address,
+    /// add Call targets with empty slot lists, and produce no entry for logs.
+    #[test]
+    fn test_hints_from_state_updates() {
+        use alloy::primitives::Bytes;
+
+        let contract = address!("0x000000000000000000000000000000000000DEAD");
+        let call_target = address!("0x000000000000000000000000000000000000BEEF");
+        let slot1 = B256::from(U256::from(1u64));
+        let slot2 = B256::from(U256::from(2u64));
+
+        let updates = vec![
+            StateUpdate::Store(IStateUpdateTypes::Store {
+                slot: slot1,
+                value: B256::ZERO,
+            }),
+            StateUpdate::Store(IStateUpdateTypes::Store {
+                slot: slot2,
+                value: B256::ZERO,
+            }),
+            StateUpdate::Call(IStateUpdateTypes::Call {
+                target: call_target,
+                value: U256::ZERO,
+                callargs: Bytes::new(),
+            }),
+            StateUpdate::Log0(IStateUpdateTypes::Log0 { data: Bytes::new() }),
+        ];
+
+        let hints = hints_from_state_updates(contract, &updates);
+
+        // Both Store slots map to contract_address.
+        assert_eq!(hints.get(&contract), Some(&vec![slot1, slot2]));
+
+        // Call target is present with an empty slot list (account-only prefetch).
+        assert_eq!(hints.get(&call_target), Some(&vec![]));
+
+        // Log produces no entry — only contract and call_target.
+        assert_eq!(hints.len(), 2);
     }
 }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -734,6 +734,8 @@ fn hints_from_state_updates(
     state_updates: &[StateUpdate],
 ) -> HashMap<Address, Vec<B256>> {
     let mut hints: HashMap<Address, Vec<B256>> = HashMap::new();
+    // Always prefetch contract_address account info even if there are no Store updates.
+    hints.entry(contract_address).or_default();
     for update in state_updates {
         match update {
             StateUpdate::Store(s) => {
@@ -780,17 +782,15 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
     let caller_address = tx_request.from.unwrap_or_default();
 
     // Collect storage hints from the EIP-2930 access list before tx_request
-    // is consumed by get_trace_from_call. Only entries with actual slot keys are
-    // included — address-only EIP-2930 entries have no storage to prefetch.
+    // is consumed by get_trace_from_call. Address-only entries (no storage keys)
+    // are included with an empty slot list so their account info is prefetched.
     let mut storage_hints: HashMap<Address, Vec<B256>> = HashMap::new();
     if let Some(al) = &tx_request.access_list {
         for item in al.iter() {
-            if !item.storage_keys.is_empty() {
-                storage_hints
-                    .entry(item.address)
-                    .or_default()
-                    .extend(item.storage_keys.iter().copied());
-            }
+            storage_hints
+                .entry(item.address)
+                .or_default()
+                .extend(item.storage_keys.iter().copied());
         }
     }
 
@@ -1264,8 +1264,9 @@ mod tests {
         );
     }
 
-    /// `hints_from_state_updates` must map Store slots to contract_address,
-    /// add Call targets with empty slot lists, and produce no entry for logs.
+    /// `hints_from_state_updates` must always include contract_address (even
+    /// with no Store updates), map Store slots to it, add Call targets with
+    /// empty slot lists, and produce no entry for logs.
     #[test]
     fn test_hints_from_state_updates() {
         use alloy::primitives::Bytes;
@@ -1302,5 +1303,21 @@ mod tests {
 
         // Log produces no entry — only contract and call_target.
         assert_eq!(hints.len(), 2);
+    }
+
+    /// contract_address must be prefetched even when there are no Store updates.
+    #[test]
+    fn test_hints_from_state_updates_contract_always_present() {
+        use alloy::primitives::Bytes;
+
+        let contract = address!("0x000000000000000000000000000000000000DEAD");
+        let updates = vec![StateUpdate::Log0(IStateUpdateTypes::Log0 {
+            data: Bytes::new(),
+        })];
+
+        let hints = hints_from_state_updates(contract, &updates);
+
+        assert_eq!(hints.get(&contract), Some(&vec![]));
+        assert_eq!(hints.len(), 1);
     }
 }

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -302,7 +302,7 @@ pub async fn prefetch_slots_into_cache(
 
     // Phase 2: collect results and insert into cache_db.
     while let Some(task_res) = set.join_next().await {
-        let (address, proof_res, code_res) = task_res.context("prefetch task panicked")?;
+        let (address, proof_res, code_res) = task_res.context("prefetch task failed")?;
 
         let proof = match proof_res {
             Ok(p) => p,

--- a/crates/evmsketch/src/simple_rpc_db.rs
+++ b/crates/evmsketch/src/simple_rpc_db.rs
@@ -242,27 +242,30 @@ impl SimpleRpcDb {
 
 /// Prefetch accounts and storage slots into `cache_db` via `eth_getProof`.
 ///
-/// For each `(address, keys)` entry, `eth_getProof` and `eth_getCode` are
-/// issued concurrently via `tokio::join!`: the proof call returns account
-/// metadata and all listed storage values; the code call covers contract
-/// accounts (`code_hash != KECCAK_EMPTY`) and is joined in parallel to avoid
-/// a sequential second round-trip. For EOAs the code response is discarded.
-/// This replaces K per-slot `eth_getStorageAt` calls per address with two
-/// concurrent RPC calls regardless of K.
+/// All addresses are fetched concurrently in two phases:
 ///
-/// Duplicate keys within an address entry are deduplicated before the call
-/// to avoid inflating the proof payload.
+/// **Phase 1 — fan-out**: one `tokio::task` is spawned per address. Each task
+/// issues `eth_getProof` and `eth_getCode` in parallel via `tokio::join!`.
+/// `cache_db` is not captured by any task; only the cloned provider and
+/// primitive values are moved in, so the mutable borrow is free for Phase 2.
 ///
-/// The results are inserted into `cache_db` so that EVM execution reads them
-/// from the in-process cache without any further RPC calls. Cold-miss slots
-/// (accessed during execution but not present in `slots`) still fall back to
+/// **Phase 2 — collect**: tasks are joined one at a time and their results are
+/// inserted into `cache_db`. Total latency is bounded by the slowest single
+/// address rather than the sum of all addresses.
+///
+/// Addresses with an empty key list (e.g. `StateUpdate::Call` targets) are
+/// fetched with `eth_getProof(address, [])`, which returns account metadata
+/// (balance, nonce, code hash) without storage proofs — enough to warm the
+/// `basic_ref` cache and eliminate a blocking RPC call from revm execution.
+///
+/// Duplicate keys within an entry are deduplicated before the call. Cold-miss
+/// slots (accessed during execution but absent from `slots`) fall back to
 /// individual `eth_getStorageAt` calls via `storage_ref`, so an incomplete
 /// hint set is safe.
 ///
-/// If `eth_getProof` is not supported by the endpoint the `proof_supported`
-/// flag on the underlying `SimpleRpcDb` is cleared (matching the behaviour of
-/// `basic_ref`) and all remaining addresses are skipped — their storage slots
-/// will be fetched on demand.
+/// If `eth_getProof` is not supported by the endpoint, `proof_supported` is
+/// cleared and remaining tasks are aborted — their slots fall back to on-demand
+/// `eth_getStorageAt`.
 #[tracing::instrument(
     name = "evmsketch.rpc.prefetch",
     skip(cache_db, slots),
@@ -273,28 +276,33 @@ pub async fn prefetch_slots_into_cache(
     cache_db: &mut CacheDB<SimpleRpcDb>,
     slots: &HashMap<Address, Vec<B256>>,
 ) -> anyhow::Result<()> {
-    for (address, keys) in slots {
-        if keys.is_empty() {
-            continue;
-        }
-        if !cache_db.db.proof_supported.load(Ordering::Relaxed) {
-            // eth_getProof was already rejected; remaining slots fall back to
-            // on-demand eth_getStorageAt during EVM execution.
-            break;
-        }
+    if slots.is_empty() || !cache_db.db.proof_supported.load(Ordering::Relaxed) {
+        return Ok(());
+    }
 
-        let provider = cache_db.db.provider.clone();
-        let block = cache_db.db.block_number;
+    let provider = cache_db.db.provider.clone();
+    let block = cache_db.db.block_number;
 
+    // Phase 1: fan out all (eth_getProof, eth_getCode) pairs concurrently.
+    let mut set = tokio::task::JoinSet::new();
+    for (&address, keys) in slots {
+        let provider = provider.clone();
         let unique_keys: Vec<B256> = {
             let mut seen = std::collections::HashSet::new();
             keys.iter().copied().filter(|k| seen.insert(*k)).collect()
         };
+        set.spawn(async move {
+            let (proof_res, code_res) = tokio::join!(
+                provider.get_proof(address, unique_keys).number(block),
+                provider.get_code_at(address).number(block),
+            );
+            (address, proof_res, code_res)
+        });
+    }
 
-        let (proof_res, code_res) = tokio::join!(
-            provider.get_proof(*address, unique_keys).number(block),
-            provider.get_code_at(*address).number(block),
-        );
+    // Phase 2: collect results and insert into cache_db.
+    while let Some(task_res) = set.join_next().await {
+        let (address, proof_res, code_res) = task_res.context("prefetch task panicked")?;
 
         let proof = match proof_res {
             Ok(p) => p,
@@ -305,12 +313,12 @@ pub async fn prefetch_slots_into_cache(
                     "eth_getProof unsupported during prefetch; \
                      storage slots will be fetched on demand"
                 );
-                break;
+                set.abort_all();
+                return Ok(());
             }
             // Any other eth_getProof failure (payload limit, transient error,
             // etc.) is not fatal — the slot will be fetched on demand via
-            // eth_getStorageAt during EVM execution. Log a warning so the issue
-            // is visible but do not abort the estimation.
+            // eth_getStorageAt. Log a warning so the issue is visible.
             Err(e) => {
                 tracing::warn!(
                     address = %address,
@@ -324,8 +332,6 @@ pub async fn prefetch_slots_into_cache(
         let bytecode = if proof.code_hash != KECCAK_EMPTY {
             match code_res {
                 Ok(b) => Bytecode::new_raw(b),
-                // If we can't fetch code, skip inserting this account — the
-                // EVM will fetch account info on demand via basic_ref.
                 Err(e) => {
                     tracing::warn!(
                         address = %address,
@@ -340,7 +346,7 @@ pub async fn prefetch_slots_into_cache(
         };
 
         cache_db.insert_account_info(
-            *address,
+            address,
             AccountInfo {
                 balance: proof.balance,
                 nonce: proof.nonce,
@@ -352,7 +358,7 @@ pub async fn prefetch_slots_into_cache(
         for sp in &proof.storage_proof {
             let slot = U256::from_be_bytes(sp.key.as_b256().0);
             cache_db
-                .insert_account_storage(*address, slot, sp.value)
+                .insert_account_storage(address, slot, sp.value)
                 .with_context(|| format!("insert_account_storage {address}[{slot}]"))?;
         }
 
@@ -362,6 +368,7 @@ pub async fn prefetch_slots_into_cache(
             "prefetched account and storage via eth_getProof",
         );
     }
+
     Ok(())
 }
 
@@ -503,6 +510,67 @@ mod tests {
         assert_eq!(
             cached, None,
             "slot must not be in cache when proof is unsupported"
+        );
+    }
+
+    /// An address with an empty key list (e.g. from a `StateUpdate::Call` target)
+    /// must still have its account info prefetched — `eth_getProof(addr, [])` returns
+    /// balance/nonce/code_hash without storage proofs.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_prefetch_account_only_empty_keys() {
+        use alloy_provider::RootProvider;
+        use alloy_provider::network::AnyNetwork;
+        use alloy_rpc_client::RpcClient;
+        use alloy_transport::mock::{Asserter, MockTransport};
+        use revm::primitives::U256;
+        use std::collections::HashMap;
+
+        use alloy::primitives::address;
+
+        let addr = address!("0000000000000000000000000000000000009abc");
+
+        let asserter = Asserter::new();
+        // eth_getProof with empty keys — returns account info, empty storage_proof.
+        asserter.push_success(&serde_json::json!({
+            "address": format!("{addr:#x}"),
+            "balance": "0x64",
+            "codeHash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            "nonce": "0x1",
+            "storageHash": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "accountProof": [],
+            "storageProof": []
+        }));
+        // eth_getCode fires concurrently; KECCAK_EMPTY so result is discarded.
+        asserter.push_success(&"0x");
+
+        let transport = MockTransport::new(asserter.clone());
+        let client = RpcClient::new(transport, true);
+        let provider: RootProvider<AnyNetwork> = RootProvider::new(client);
+
+        let db = SimpleRpcDb::new(provider, 42);
+        let mut cache_db = CacheDB::new(db);
+
+        // Empty key list — account-only prefetch.
+        let mut hints = HashMap::new();
+        hints.insert(addr, vec![]);
+
+        prefetch_slots_into_cache(&mut cache_db, &hints)
+            .await
+            .expect("prefetch should succeed for empty-key address");
+
+        // Account info must be in the cache (balance = 0x64, nonce = 1).
+        let cached_account = cache_db.cache.accounts.get(&addr);
+        assert!(
+            cached_account.is_some(),
+            "account info should be prefetched even with empty key list"
+        );
+        let info = cached_account.unwrap().info.clone();
+        assert_eq!(info.balance, U256::from(0x64u64), "balance mismatch");
+        assert_eq!(info.nonce, 1, "nonce mismatch");
+
+        assert!(
+            asserter.pop_response().is_none(),
+            "unexpected extra RPC call after prefetch"
         );
     }
 


### PR DESCRIPTION
## Summary

Eliminates the dominant source of serial latency inside `estimate_state_changes_gas`: the per-slot `eth_getStorageAt` round-trips that revm previously triggered one-at-a-time via `storage_ref` during execution.

### What changed

**`hints_from_state_updates` (new helper in `lib.rs`)**
Before running the gas estimator, derive a prefetch hint map directly from the parsed state updates:
- `Store` updates → all slots map to `contract_address`; one `eth_getProof` call returns every value in a single round-trip.
- `Call` updates → target addresses are added with empty slot lists, prefetching account info (balance/nonce/code) so `basic_ref` never blocks.
- `Log*` updates → carry no addressable state, produce no hints.

These hints are merged with any EIP-2930 access-list hints already collected, then passed to `estimate_state_changes_gas_with_hints`. Previously that path was only taken when an access list was present; now it always runs.

**`prefetch_slots_into_cache` — parallel fan-out (`simple_rpc_db.rs`)**
Replaced the sequential address loop with a two-phase `tokio::task::JoinSet` approach:
1. **Fan-out**: one task per address, each issuing `eth_getProof` + `eth_getCode` concurrently via `tokio::join!`. `cache_db` is not captured — only the cloned provider and primitive values move into tasks.
2. **Collect**: results are joined one at a time and inserted into `cache_db`.

Total prefetch latency is now bounded by the slowest single address rather than the sum of all addresses.

Also removed the `if keys.is_empty() { continue; }` guard: addresses with no known slots (e.g. `Call` targets) now issue `eth_getProof(address, [])` to warm the account info cache.

## Test plan
- [ ] `cargo fmt --all` — no changes
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo test` — 25 tests pass, 3 ignored (require `RPC_URL`)
- [ ] New tests: `test_hints_from_state_updates`, `test_prefetch_account_only_empty_keys`
- [ ] End-to-end with a live Sepolia node: `make bench-rpc RPC_URL=<node>` to confirm latency improvement

## Related
- Closes https://github.com/gas-killer/gas-analyzer/issues/151
- Epic: https://github.com/gas-killer/roadmap/issues/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)