### PR TITLE
feat: report gas estimates for both BLS and Schnorr signature schemes

### DIFF
--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -191,13 +191,8 @@ impl SignatureGasEstimate {
         gas_used: u64,
         approx_gas_price_per_unit: f64,
     ) -> Self {
-        let gas_estimate = signature_type.total_gas_estimate(base_estimate);
-        let gas_savings = gas_used.saturating_sub(gas_estimate);
-        let percent_savings = if gas_used > 0 {
-            (gas_savings * 100) as f64 / gas_used as f64
-        } else {
-            0.0
-        };
+        let (gas_estimate, gas_savings, percent_savings) =
+            signature_type.savings(base_estimate, gas_used);
         Self {
             gas_estimate,
             estimated_gas_cost: approx_gas_price_per_unit * gas_estimate as f64,

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -52,8 +52,8 @@ fn impl_slot() -> U256 {
 }
 
 use gas_analyzer_core::{
-    Opcode, RevertingContext, StateUpdate, TURETZKY_UPPER_GAS_LIMIT, compute_state_updates,
-    encode_state_updates_to_abi, encode_state_updates_to_sol,
+    Opcode, RevertingContext, SignatureType, StateUpdate, TURETZKY_UPPER_GAS_LIMIT_SCHNORR,
+    compute_state_updates, encode_state_updates_to_abi, encode_state_updates_to_sol,
 };
 use gas_analyzer_rpc::get_tx_trace;
 
@@ -61,7 +61,13 @@ use gas_analyzer_rpc::get_tx_trace;
 // Report Types
 // ============================================================================
 
-/// Gas analysis report for a transaction
+/// Gas analysis report for a transaction.
+///
+/// The GasKiller gas estimate is the base state-change execution cost plus the
+/// Turetzky upper gas limit, which depends on the signature scheme used to verify the
+/// aggregated operator attestation on-chain. The estimate, estimated cost, and savings
+/// are therefore reported per scheme (`_bls` / `_schnorr`) alongside the shared base
+/// estimate. Fields are flat rather than nested so the report serializes to CSV.
 #[derive(Serialize)]
 pub struct GasKillerReport {
     pub time: DateTime<Utc>,
@@ -72,10 +78,15 @@ pub struct GasKillerReport {
     pub gas_used: u64,
     pub gas_cost: u128,
     pub approx_gas_unit_price: f64,
-    pub gaskiller_gas_estimate: u64,
-    pub gaskiller_estimated_gas_cost: f64,
-    pub gas_savings: u64,
-    pub percent_savings: f64,
+    pub gaskiller_base_gas_estimate: u64,
+    pub gaskiller_gas_estimate_bls: u64,
+    pub gaskiller_gas_estimate_schnorr: u64,
+    pub gaskiller_estimated_gas_cost_bls: f64,
+    pub gaskiller_estimated_gas_cost_schnorr: f64,
+    pub gas_savings_bls: u64,
+    pub gas_savings_schnorr: u64,
+    pub percent_savings_bls: f64,
+    pub percent_savings_schnorr: f64,
     pub function_selector: FixedBytes<4>,
     pub skipped_opcodes: String,
     pub error_log: Option<String>,
@@ -109,10 +120,15 @@ impl GasKillerReport {
             gas_used: receipt.gas_used,
             gas_cost: receipt.effective_gas_price,
             approx_gas_unit_price: receipt.effective_gas_price as f64 / receipt.gas_used as f64,
-            gaskiller_gas_estimate: 0,
-            gaskiller_estimated_gas_cost: 0.0,
-            gas_savings: 0,
-            percent_savings: 0.0,
+            gaskiller_base_gas_estimate: 0,
+            gaskiller_gas_estimate_bls: 0,
+            gaskiller_gas_estimate_schnorr: 0,
+            gaskiller_estimated_gas_cost_bls: 0.0,
+            gaskiller_estimated_gas_cost_schnorr: 0.0,
+            gas_savings_bls: 0,
+            gas_savings_schnorr: 0,
+            percent_savings_bls: 0.0,
+            percent_savings_schnorr: 0.0,
             function_selector,
             skipped_opcodes: "".to_string(),
             error_log: Some(format!("{e:?}")),
@@ -141,10 +157,15 @@ impl GasKillerReport {
             gas_used: receipt.gas_used,
             gas_cost: receipt.effective_gas_price,
             approx_gas_unit_price: details.approx_gas_price_per_unit,
-            gaskiller_gas_estimate: details.gaskiller_gas_estimate,
-            gaskiller_estimated_gas_cost: details.gaskiller_estimated_gas_cost,
-            gas_savings: details.gas_savings,
-            percent_savings: details.percent_savings,
+            gaskiller_base_gas_estimate: details.gaskiller_base_gas_estimate,
+            gaskiller_gas_estimate_bls: details.bls.gas_estimate,
+            gaskiller_gas_estimate_schnorr: details.schnorr.gas_estimate,
+            gaskiller_estimated_gas_cost_bls: details.bls.estimated_gas_cost,
+            gaskiller_estimated_gas_cost_schnorr: details.schnorr.estimated_gas_cost,
+            gas_savings_bls: details.bls.gas_savings,
+            gas_savings_schnorr: details.schnorr.gas_savings,
+            percent_savings_bls: details.bls.percent_savings,
+            percent_savings_schnorr: details.schnorr.percent_savings,
             function_selector: details.function_selector,
             skipped_opcodes: details.skipped_opcodes,
             error_log: None,
@@ -152,13 +173,46 @@ impl GasKillerReport {
     }
 }
 
+/// Gas figures for a single signature scheme, derived from the base estimate.
+#[derive(Debug, Clone, Copy)]
+pub struct SignatureGasEstimate {
+    pub gas_estimate: u64,
+    pub estimated_gas_cost: f64,
+    pub gas_savings: u64,
+    pub percent_savings: f64,
+}
+
+impl SignatureGasEstimate {
+    /// Combine the base state-change estimate with a scheme's Turetzky upper gas limit
+    /// and derive the estimated cost and savings against the transaction's actual usage.
+    fn compute(
+        signature_type: SignatureType,
+        base_estimate: u64,
+        gas_used: u64,
+        approx_gas_price_per_unit: f64,
+    ) -> Self {
+        let gas_estimate = signature_type.total_gas_estimate(base_estimate);
+        let gas_savings = gas_used.saturating_sub(gas_estimate);
+        let percent_savings = if gas_used > 0 {
+            (gas_savings * 100) as f64 / gas_used as f64
+        } else {
+            0.0
+        };
+        Self {
+            gas_estimate,
+            estimated_gas_cost: approx_gas_price_per_unit * gas_estimate as f64,
+            gas_savings,
+            percent_savings,
+        }
+    }
+}
+
 /// Details for gas estimation report
 pub struct ReportDetails {
     pub approx_gas_price_per_unit: f64,
-    pub gaskiller_gas_estimate: u64,
-    pub gaskiller_estimated_gas_cost: f64,
-    pub gas_savings: u64,
-    pub percent_savings: f64,
+    pub gaskiller_base_gas_estimate: u64,
+    pub bls: SignatureGasEstimate,
+    pub schnorr: SignatureGasEstimate,
     pub function_selector: FixedBytes<4>,
     pub skipped_opcodes: String,
 }
@@ -480,9 +534,11 @@ pub async fn gas_estimate_block(
     let block_number = all_receipts[0]
         .block_number
         .expect("couldn't find block number in receipt");
+    // Compare against the smallest signature floor so we keep any transaction that
+    // could show savings under at least one scheme.
     let receipts: Vec<_> = all_receipts
         .into_iter()
-        .filter(|x| x.gas_used > TURETZKY_UPPER_GAS_LIMIT && x.to.is_some())
+        .filter(|x| x.gas_used > TURETZKY_UPPER_GAS_LIMIT_SCHNORR && x.to.is_some())
         .collect();
 
     println!("got {} receipts for block {}", receipts.len(), block_number);
@@ -514,13 +570,15 @@ pub async fn gas_estimate_tx(
         .await?
         .ok_or_else(|| anyhow!("could not get receipt for tx {}", tx_hash))?;
     let smart_contract_tx = invokes_smart_contract(&provider, &receipt).await?;
-    if receipt.gas_used <= TURETZKY_UPPER_GAS_LIMIT
+    // Compare against the smallest signature floor so we keep any transaction that could
+    // show savings under at least one scheme.
+    if receipt.gas_used <= TURETZKY_UPPER_GAS_LIMIT_SCHNORR
         || !smart_contract_tx
         || receipt.to.is_none()
         || !receipt.status()
     {
         bail!(
-            "Skipped: either 1) gas used is less than or equal to TUGL or 2) no smart contract calls are made or 3) contract creation transaction or 4) transaction failed"
+            "Skipped: either 1) gas used is less than or equal to the smallest Turetzky upper gas limit or 2) no smart contract calls are made or 3) contract creation transaction or 4) transaction failed"
         )
     }
 
@@ -578,23 +636,29 @@ pub async fn gaskiller_reporter(
         .into_iter()
         .collect::<Vec<_>>()
         .join(", ");
-    let gaskiller_gas_estimate = gk
+    let base_gas_estimate = gk
         .estimate_state_changes_gas(
             receipt.to.unwrap(), // already check if this is None in gas_estimate_tx
             &state_updates,
         )
         .await?;
-    let gaskiller_gas_estimate = gaskiller_gas_estimate + TURETZKY_UPPER_GAS_LIMIT;
     let gas_used = receipt.gas_used;
     let approx_gas_price_per_unit: f64 = receipt.effective_gas_price as f64 / gas_used as f64;
-    let gaskiller_estimated_gas_cost = approx_gas_price_per_unit * gaskiller_gas_estimate as f64;
-    let gas_savings = gas_used.saturating_sub(gaskiller_gas_estimate);
     Ok(ReportDetails {
         approx_gas_price_per_unit,
-        gaskiller_gas_estimate,
-        gaskiller_estimated_gas_cost,
-        gas_savings,
-        percent_savings: (gas_savings * 100) as f64 / gas_used as f64,
+        gaskiller_base_gas_estimate: base_gas_estimate,
+        bls: SignatureGasEstimate::compute(
+            SignatureType::Bls,
+            base_gas_estimate,
+            gas_used,
+            approx_gas_price_per_unit,
+        ),
+        schnorr: SignatureGasEstimate::compute(
+            SignatureType::Schnorr,
+            base_gas_estimate,
+            gas_used,
+            approx_gas_price_per_unit,
+        ),
         function_selector,
         skipped_opcodes,
     })

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -185,6 +185,8 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 let report = gas_estimate_tx(provider, bytes.into(), &gk).await?;
 
                 // Print gas analysis
+                use gas_analyzer_core::SignatureType;
+
                 println!("\n{}", "=== Gas Analysis ===".blue().bold());
                 println!("Transaction: 0x{}", hex::encode(bytes));
                 println!(
@@ -194,14 +196,34 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 );
                 println!("Gas used: {}", gas_used);
                 println!(
-                    "GasKiller gas estimate: {} {}",
-                    report.gaskiller_gas_estimate,
+                    "GasKiller base estimate (before signature floor): {} {}",
+                    report.gaskiller_base_gas_estimate,
                     "(measured via Anvil)".cyan()
                 );
-                println!(
-                    "Gas savings: {} ({:.2}%)",
-                    report.gas_savings, report.percent_savings
-                );
+                // Report the total estimate and savings for each signature scheme, since
+                // the Turetzky upper gas limit added to the base estimate differs per scheme.
+                for (signature_type, gas_estimate, gas_savings, percent_savings) in [
+                    (
+                        SignatureType::Bls,
+                        report.gaskiller_gas_estimate_bls,
+                        report.gas_savings_bls,
+                        report.percent_savings_bls,
+                    ),
+                    (
+                        SignatureType::Schnorr,
+                        report.gaskiller_gas_estimate_schnorr,
+                        report.gas_savings_schnorr,
+                        report.percent_savings_schnorr,
+                    ),
+                ] {
+                    println!(
+                        "\n{} (Turetzky upper gas limit: {})",
+                        format!("[{}]", signature_type.label()).bold(),
+                        signature_type.turetzky_upper_gas_limit()
+                    );
+                    println!("  GasKiller gas estimate: {}", gas_estimate);
+                    println!("  Gas savings: {} ({:.2}%)", gas_savings, percent_savings);
+                }
                 if let Some(error) = &report.error_log {
                     if cli_args.debug {
                         println!("{}: {}", "Error".red(), error);
@@ -277,12 +299,15 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
 
                 // Get gas estimate using the state updates extracted from the actual trace
                 use gas_analyzer_core::{
-                    TURETZKY_UPPER_GAS_LIMIT, encode_state_updates_to_abi,
-                    estimate_gas_from_state_updates,
+                    SignatureType, encode_state_updates_to_abi, estimate_gas_from_state_updates,
                 };
                 use gas_analyzer_evmsketch::GasKillerEvmSketchDefault;
 
-                let (gas_estimate, is_heuristic) = if use_fallback || state_updates.is_empty() {
+                // Base estimate is the state-change execution cost only; the Turetzky
+                // upper gas limit (which depends on the signature scheme) is added per
+                // scheme when the estimate is reported.
+                let (base_gas_estimate, is_heuristic) = if use_fallback || state_updates.is_empty()
+                {
                     // Use heuristic estimation when trace extraction failed or no state updates
                     let gk = GasKillerEvmSketchDefault::builder(rpc_url.clone())
                         .at_block(BlockNumberOrTag::Number(block_number))
@@ -311,7 +336,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                             return Err(anyhow::Error::msg(msg));
                         }
                     };
-                    (fallback_estimate + TURETZKY_UPPER_GAS_LIMIT, true)
+                    (fallback_estimate, true)
                 } else {
                     // Normal path: try measured gas estimation using extracted state updates
                     // Get the contract address from the receipt
@@ -357,7 +382,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                         &preceding_txs,
                         tx_value,
                     ) {
-                        Ok(gas) => (gas + TURETZKY_UPPER_GAS_LIMIT, false),
+                        Ok(gas) => (gas, false),
                         Err(e) => {
                             // Fall back to heuristic estimation
                             println!(
@@ -401,7 +426,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                             }
                             let heuristic =
                                 estimate_gas_from_state_updates(&state_updates, call_gas_total);
-                            (heuristic + TURETZKY_UPPER_GAS_LIMIT, true)
+                            (heuristic, true)
                         }
                     }
                 };
@@ -426,13 +451,6 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 }
 
                 // Print gas analysis
-                let gas_savings = gas_used.saturating_sub(gas_estimate);
-                let percent_savings = if gas_used > 0 {
-                    (gas_savings as f64 / gas_used as f64) * 100.0
-                } else {
-                    0.0
-                };
-
                 println!("\n{}", "=== Gas Analysis ===".blue().bold());
                 println!("Transaction: 0x{}", hex::encode(bytes));
                 println!(
@@ -449,8 +467,28 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 } else {
                     "(measured via StateChangeHandler)".cyan()
                 };
-                println!("GasKiller gas estimate: {} {}", gas_estimate, estimate_type);
-                println!("Gas savings: {} ({:.2}%)", gas_savings, percent_savings);
+                println!(
+                    "GasKiller base estimate (before signature floor): {} {}",
+                    base_gas_estimate, estimate_type
+                );
+                // Report the total estimate and savings for each signature scheme, since
+                // the Turetzky upper gas limit added to the base estimate differs per scheme.
+                for signature_type in SignatureType::ALL {
+                    let gas_estimate = signature_type.total_gas_estimate(base_gas_estimate);
+                    let gas_savings = gas_used.saturating_sub(gas_estimate);
+                    let percent_savings = if gas_used > 0 {
+                        (gas_savings as f64 / gas_used as f64) * 100.0
+                    } else {
+                        0.0
+                    };
+                    println!(
+                        "\n{} (Turetzky upper gas limit: {})",
+                        format!("[{}]", signature_type.label()).bold(),
+                        signature_type.turetzky_upper_gas_limit()
+                    );
+                    println!("  GasKiller gas estimate: {}", gas_estimate);
+                    println!("  Gas savings: {} ({:.2}%)", gas_savings, percent_savings);
+                }
             }
 
             #[cfg(not(feature = "evmsketch"))]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -474,13 +474,8 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                 // Report the total estimate and savings for each signature scheme, since
                 // the Turetzky upper gas limit added to the base estimate differs per scheme.
                 for signature_type in SignatureType::ALL {
-                    let gas_estimate = signature_type.total_gas_estimate(base_gas_estimate);
-                    let gas_savings = gas_used.saturating_sub(gas_estimate);
-                    let percent_savings = if gas_used > 0 {
-                        (gas_savings as f64 / gas_used as f64) * 100.0
-                    } else {
-                        0.0
-                    };
+                    let (gas_estimate, gas_savings, percent_savings) =
+                        signature_type.savings(base_gas_estimate, gas_used);
                     println!(
                         "\n{} (Turetzky upper gas limit: {})",
                         format!("[{}]", signature_type.label()).bold(),

--- a/crates/core/src/encoding.rs
+++ b/crates/core/src/encoding.rs
@@ -49,6 +49,23 @@ impl SignatureType {
         base_estimate + self.turetzky_upper_gas_limit()
     }
 
+    /// GasKiller gas figures for this scheme against a transaction's actual usage,
+    /// returned as `(total_estimate, gas_savings, percent_savings)`. `total_estimate`
+    /// is the base state-change estimate plus this scheme's floor; `gas_savings`
+    /// saturates at zero when the estimate exceeds `gas_used`; `percent_savings` is
+    /// zero when `gas_used` is zero. Both callers (CLI and report) share this so the
+    /// savings math cannot drift between them.
+    pub fn savings(self, base_estimate: u64, gas_used: u64) -> (u64, u64, f64) {
+        let total_estimate = self.total_gas_estimate(base_estimate);
+        let gas_savings = gas_used.saturating_sub(total_estimate);
+        let percent_savings = if gas_used > 0 {
+            (gas_savings as f64 / gas_used as f64) * 100.0
+        } else {
+            0.0
+        };
+        (total_estimate, gas_savings, percent_savings)
+    }
+
     /// Human-readable label for CLI and report output.
     pub fn label(self) -> &'static str {
         match self {
@@ -199,6 +216,26 @@ mod tests {
             SignatureType::Schnorr.total_gas_estimate(base),
             base + TURETZKY_UPPER_GAS_LIMIT_SCHNORR
         );
+    }
+
+    #[test]
+    fn savings_reports_estimate_savings_and_percent() {
+        // gas_used well above the floor: savings are positive.
+        let (estimate, savings, percent) = SignatureType::Bls.savings(50_000, 1_000_000);
+        assert_eq!(estimate, 50_000 + TURETZKY_UPPER_GAS_LIMIT_BLS);
+        assert_eq!(savings, 1_000_000 - estimate);
+        assert!((percent - (savings as f64 / 1_000_000.0) * 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn savings_saturates_and_guards_zero_gas() {
+        // Estimate exceeds usage: savings saturate to zero rather than underflow.
+        let (_, savings, percent) = SignatureType::Bls.savings(1_000_000, 10_000);
+        assert_eq!(savings, 0);
+        assert_eq!(percent, 0.0);
+        // Zero gas used: percentage is defined as zero, not NaN.
+        let (_, _, percent_zero) = SignatureType::Bls.savings(0, 0);
+        assert_eq!(percent_zero, 0.0);
     }
 
     #[test]

--- a/crates/core/src/encoding.rs
+++ b/crates/core/src/encoding.rs
@@ -185,7 +185,7 @@ mod tests {
             TURETZKY_UPPER_GAS_LIMIT_SCHNORR
         );
         // Schnorr verification is cheaper on-chain, so its floor must be the smaller one.
-        assert!(TURETZKY_UPPER_GAS_LIMIT_SCHNORR < TURETZKY_UPPER_GAS_LIMIT_BLS);
+        const { assert!(TURETZKY_UPPER_GAS_LIMIT_SCHNORR < TURETZKY_UPPER_GAS_LIMIT_BLS) };
     }
 
     #[test]

--- a/crates/core/src/encoding.rs
+++ b/crates/core/src/encoding.rs
@@ -8,9 +8,55 @@ use alloy_sol_types::SolValue;
 
 use crate::types::{StateUpdate, StateUpdateType};
 
-/// The Turetzky upper gas limit - the floor gas cost for executing a GasKiller transaction.
-/// This represents the minimum overhead for the StateChangeHandler execution.
-pub const TURETZKY_UPPER_GAS_LIMIT: u64 = 250000u64;
+/// The Turetzky upper gas limit for BLS-verified attestations - the floor gas cost
+/// for executing a GasKiller transaction, i.e. the minimum StateChangeHandler
+/// execution overhead. The floor depends on the signature scheme used to verify the
+/// aggregated operator attestation on-chain, and BLS verification is the more
+/// expensive of the two schemes.
+pub const TURETZKY_UPPER_GAS_LIMIT_BLS: u64 = 250000u64;
+
+/// The Turetzky upper gas limit for Schnorr-verified attestations. See
+/// [`TURETZKY_UPPER_GAS_LIMIT_BLS`]; Schnorr verification is cheaper on-chain and so
+/// yields a lower floor.
+pub const TURETZKY_UPPER_GAS_LIMIT_SCHNORR: u64 = 27000u64;
+
+/// Signature scheme used to verify the aggregated operator attestation on-chain.
+///
+/// Each scheme has a different on-chain verification cost, which sets the GasKiller
+/// gas floor (the Turetzky upper gas limit). Gas figures are reported per scheme so
+/// callers can compare the trade-off.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SignatureType {
+    Bls,
+    Schnorr,
+}
+
+impl SignatureType {
+    /// All signature schemes, in the order they should be reported.
+    pub const ALL: [SignatureType; 2] = [SignatureType::Bls, SignatureType::Schnorr];
+
+    /// The Turetzky upper gas limit (GasKiller gas floor) for this scheme.
+    pub fn turetzky_upper_gas_limit(self) -> u64 {
+        match self {
+            SignatureType::Bls => TURETZKY_UPPER_GAS_LIMIT_BLS,
+            SignatureType::Schnorr => TURETZKY_UPPER_GAS_LIMIT_SCHNORR,
+        }
+    }
+
+    /// Add this scheme's gas floor to a base state-change estimate to obtain the
+    /// total GasKiller gas estimate.
+    pub fn total_gas_estimate(self, base_estimate: u64) -> u64 {
+        base_estimate + self.turetzky_upper_gas_limit()
+    }
+
+    /// Human-readable label for CLI and report output.
+    pub fn label(self) -> &'static str {
+        match self {
+            SignatureType::Bls => "BLS",
+            SignatureType::Schnorr => "Schnorr",
+        }
+    }
+}
 
 /// Encode state updates to Solidity types (for contract calls).
 pub fn encode_state_updates_to_sol(
@@ -122,4 +168,46 @@ pub fn encode_state_updates_to_abi(state_updates: &[StateUpdate]) -> Bytes {
     encoded.extend_from_slice(&datas_payload);
 
     Bytes::copy_from_slice(&encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turetzky_upper_gas_limit_matches_scheme() {
+        assert_eq!(
+            SignatureType::Bls.turetzky_upper_gas_limit(),
+            TURETZKY_UPPER_GAS_LIMIT_BLS
+        );
+        assert_eq!(
+            SignatureType::Schnorr.turetzky_upper_gas_limit(),
+            TURETZKY_UPPER_GAS_LIMIT_SCHNORR
+        );
+        // Schnorr verification is cheaper on-chain, so its floor must be the smaller one.
+        assert!(TURETZKY_UPPER_GAS_LIMIT_SCHNORR < TURETZKY_UPPER_GAS_LIMIT_BLS);
+    }
+
+    #[test]
+    fn total_gas_estimate_adds_scheme_floor() {
+        let base = 100_000;
+        assert_eq!(
+            SignatureType::Bls.total_gas_estimate(base),
+            base + TURETZKY_UPPER_GAS_LIMIT_BLS
+        );
+        assert_eq!(
+            SignatureType::Schnorr.total_gas_estimate(base),
+            base + TURETZKY_UPPER_GAS_LIMIT_SCHNORR
+        );
+    }
+
+    #[test]
+    fn all_covers_every_scheme_with_labels() {
+        assert_eq!(
+            SignatureType::ALL,
+            [SignatureType::Bls, SignatureType::Schnorr]
+        );
+        assert_eq!(SignatureType::Bls.label(), "BLS");
+        assert_eq!(SignatureType::Schnorr.label(), "Schnorr");
+    }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,7 +12,8 @@ pub mod types;
 
 // Re-export commonly used items
 pub use encoding::{
-    TURETZKY_UPPER_GAS_LIMIT, encode_state_updates_to_abi, encode_state_updates_to_sol,
+    SignatureType, TURETZKY_UPPER_GAS_LIMIT_BLS, TURETZKY_UPPER_GAS_LIMIT_SCHNORR,
+    encode_state_updates_to_abi, encode_state_updates_to_sol,
 };
 pub use heuristic::{
     BASE_TX_COST, LOG_BASE_COST, LOG_DATA_COST_PER_BYTE, LOG_TOPIC_COST, TraceOperations,


### PR DESCRIPTION
## Summary

The gas analyzer previously applied a single hard-coded Turetzky upper gas limit (the GasKiller gas floor). That floor depends on the signature scheme used to verify the aggregated operator attestation on-chain, so this reports figures for **both** schemes:

- **BLS** — `250000`
- **Schnorr** — `27000`

## Changes

- **`core`** — Replace `TURETZKY_UPPER_GAS_LIMIT` with `TURETZKY_UPPER_GAS_LIMIT_BLS` / `TURETZKY_UPPER_GAS_LIMIT_SCHNORR` and a `SignatureType` enum (`turetzky_upper_gas_limit()`, `total_gas_estimate()`, `label()`, `ALL`). Adds unit tests.
- **`cli`** — Both backends (evmsketch and `--anvil`) now print a base estimate (state-change cost, no floor) followed by a per-scheme block with the total estimate and savings.
- **`anvil`** — `GasKillerReport` gains a shared `gaskiller_base_gas_estimate` plus `_bls`/`_schnorr` variants of estimate, cost, and savings, derived via a new `SignatureGasEstimate::compute` helper. Receipt filters now compare against the smaller (Schnorr) floor so any tx that could save under either scheme is retained.

## Notes

- **CSV schema change:** `GasKillerReport` columns changed (`gaskiller_gas_estimate` → `gaskiller_gas_estimate_bls` / `_schnorr`, etc.). Downstream CSV consumers need the new headers.
- **WASM untouched:** its `gas_estimate` deliberately excludes the floor (the frontend applies it), so it is unaffected.

## Testing

- `cargo check` / `cargo clippy -- -D warnings` clean on default members and the anvil-feature paths (anvil crate + CLI `--features anvil`).
- `cargo fmt --all --check` clean; new core unit tests pass.