### PR TITLE
feat: unbounded simulation mode (SimProfile::Unbounded) — break the block gas limit off-chain, keep the payload inside one transaction

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -28,7 +28,6 @@ jobs:
             --exclude indexer-resolver \
             --exclude indexer-service \
             --exclude indexer-web \
-            --features gas-analyzer-evmsketch/anvil \
             --all-targets -- -D warnings
 
       # A single clippy run only ever sees one feature configuration, so anything behind a
@@ -82,8 +81,11 @@ jobs:
       - name: cargo test (anvil)
         run: cargo test -p gas-analyzer-anvil -p gas-analyzer-cli --features gas-analyzer-cli/anvil --no-default-features
 
+      # `#[ignore]`d so a `cargo test` without foundry skips rather than fails; foundry is installed
+      # above, so run them explicitly here. Name-filtered to this module so the RPC-backed ignored
+      # tests (which need RPC_URL) are not pulled in.
       - name: cargo test (evmsketch anvil integration)
-        run: cargo test -p gas-analyzer-evmsketch --features anvil
+        run: cargo test -p gas-analyzer-evmsketch anvil_integration -- --ignored
 
   test-wasm:
     runs-on: ubuntu-latest

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod constants;
 pub mod encoding;
 pub mod heuristic;
 pub mod prestate;
+pub mod sim_profile;
 pub mod trace;
 pub mod types;
 
@@ -23,6 +24,10 @@ pub use heuristic::{
 };
 pub use prestate::{
     PrestateEligibility, build_state_updates_from_prestate, classify_prestate_eligibility,
+};
+pub use sim_profile::{
+    SimProfile, UNBOUNDED_BLOCK_GAS_LIMIT, UNBOUNDED_TX_GAS_LIMIT, UnboundedShape,
+    UnboundedShapeViolation, validate_unbounded_shape,
 };
 pub use trace::{
     compute_state_updates, compute_state_updates_canonical, copy_memory, parse_trace_memory,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,8 +26,9 @@ pub use prestate::{
     PrestateEligibility, build_state_updates_from_prestate, classify_prestate_eligibility,
 };
 pub use sim_profile::{
-    SimProfile, UNBOUNDED_BLOCK_GAS_LIMIT, UNBOUNDED_TX_GAS_LIMIT, UnboundedShape,
-    UnboundedShapeViolation, validate_unbounded_shape,
+    SimProfile, UNBOUNDED_BLOCK_GAS_LIMIT, UNBOUNDED_COLD_SSTORE_COST,
+    UNBOUNDED_PAYLOAD_GAS_BUDGET, UNBOUNDED_TX_GAS_LIMIT, UnboundedCost, UnboundedCostViolation,
+    estimate_applied_payload_gas, validate_unbounded_cost,
 };
 pub use trace::{
     compute_state_updates, compute_state_updates_canonical, copy_memory, parse_trace_memory,

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -151,6 +151,45 @@ const LOG_BYTE: u64 = 8;
 /// Intrinsic cost of the `verifyAndUpdate` transaction that carries the payload.
 const TX_BASE: u64 = 21_000;
 
+/// Intrinsic gas per byte of payload calldata: 4 per zero byte, 16 per non-zero byte
+/// (EIP-2028 pricing, i.e. 4 gas per EIP-7623 *token*).
+const CALLDATA_ZERO_BYTE: u64 = 4;
+const CALLDATA_NONZERO_BYTE: u64 = 16;
+
+/// EIP-7623 floor price per calldata token, where a token is one zero byte or a quarter of a
+/// non-zero byte. A transaction pays the *larger* of its execution total and this floor, so
+/// [`estimate_applied_payload_gas`] has to evaluate both.
+const CALLDATA_FLOOR_TOKEN: u64 = 10;
+const CALLDATA_FLOOR_NONZERO_TOKENS: u64 = 4;
+
+/// Fixed cost of entering `verifyAndUpdate`'s apply loop: decoding the two outer arrays and
+/// setting up memory, independent of what they hold.
+///
+/// Together with [`UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE`] this covers the difference between an
+/// op's raw EVM price and what it costs to *dispatch* that op out of an ABI-encoded payload — a
+/// term the reporting estimators never needed, because revm charges it automatically when it
+/// executes real calldata.
+pub const UNBOUNDED_APPLY_BASE_GAS: u64 = 2_000;
+
+/// Cost of decoding and dispatching one byte of encoded payload inside `verifyAndUpdate`:
+/// `calldataload`ing it, copying it into memory, and walking the element it belongs to.
+///
+/// Charged per payload byte rather than per update because that is what the work is proportional
+/// to — an update's decode cost tracks the bytes it occupies, not its existence. Measured against
+/// the `StateChangeHandlerGasEstimator` handler across store- and log-shaped payloads at 7.9–12.9
+/// gas per byte (the top of that range being logs, which carry more envelope per byte), so 14
+/// dominates every observed shape with ≥8% margin.
+///
+/// `analytic_bound_dominates_measured_apply_cost` in `gas-analyzer-estimator` pins this and
+/// [`UNBOUNDED_APPLY_BASE_GAS`] against that measurement, so neither can silently drift below what
+/// applying a payload really costs.
+///
+/// Caveat worth knowing: the measurement is against the estimator handler, which is what this
+/// analyzer's own gas figures run through — not the production `verifyAndUpdate` in the
+/// solidity-sdk. If that handler's decode loop is materially more expensive, this constant needs
+/// re-measuring against it.
+pub const UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE: u64 = 14;
+
 /// Summary of a payload that passed [`validate_unbounded_cost`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnboundedCost {
@@ -165,8 +204,10 @@ pub struct UnboundedCost {
     pub calls: usize,
     /// Number of `Log0`–`Log4` ops.
     pub logs: usize,
-    /// Upper bound on the gas needed to apply this payload on-chain, including the transaction's
-    /// intrinsic cost and the signature-verification floor.
+    /// Upper bound on the gas needed to apply this payload on-chain: the transaction's intrinsic
+    /// cost, the signature-verification floor, each op's execution cost, the intrinsic gas for the
+    /// encoded payload's own bytes, and `verifyAndUpdate`'s decode/dispatch overhead. See
+    /// [`estimate_applied_payload_gas`].
     pub applied_gas_upper_bound: u64,
 }
 
@@ -232,6 +273,21 @@ impl std::error::Error for UnboundedCostViolation {}
 /// A pure function of its arguments, which is the point: it decides whether a payload is acceptable,
 /// so every operator must reach the same verdict from the same payload. Anything that consulted live
 /// chain state could put two honest operators on opposite sides of the boundary.
+///
+/// Three things are priced, and the payload has to carry all of them:
+///
+/// 1. **Execution** — the raw EVM cost of each op ([`UNBOUNDED_COLD_SSTORE_COST`], the `LOG*`
+///    schedule) plus `external_call_gas`.
+/// 2. **Transport** — intrinsic gas for the ABI-encoded payload's bytes. This scales with the
+///    number of updates, so unlike the reporting estimators (which get it for free from revm
+///    executing real calldata) the gate must charge it explicitly or it under-prices every
+///    multi-slot payload.
+/// 3. **Dispatch** — [`UNBOUNDED_APPLY_BASE_GAS`] plus
+///    [`UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE`] for decoding the payload and walking it inside
+///    `verifyAndUpdate`.
+///
+/// The return value is `max(execution + transport, EIP-7623 floor)`, mirroring how a transaction is
+/// actually priced: a payload whose bytes dominate its execution pays the floor instead.
 pub fn estimate_applied_payload_gas(
     updates: &[StateUpdate],
     external_call_gas: u64,
@@ -239,7 +295,8 @@ pub fn estimate_applied_payload_gas(
 ) -> u64 {
     let mut gas = TX_BASE
         .saturating_add(signature_floor)
-        .saturating_add(external_call_gas);
+        .saturating_add(external_call_gas)
+        .saturating_add(UNBOUNDED_APPLY_BASE_GAS);
     for update in updates {
         gas = gas.saturating_add(match update {
             StateUpdate::Store(_) => UNBOUNDED_COLD_SSTORE_COST,
@@ -254,7 +311,26 @@ pub fn estimate_applied_payload_gas(
             StateUpdate::Create(_) | StateUpdate::Create2(_) => 0,
         });
     }
-    gas
+
+    // Transport and dispatch, both priced off the real encoded payload rather than a per-op
+    // approximation: that keeps dense and sparse slot values honest, covers a log's data bytes,
+    // and stays correct if the encoding changes. The payload is what a `verifyAndUpdate`
+    // transaction carries, bar the selector and attestation, which ride inside `signature_floor`.
+    let payload = crate::encoding::encode_state_updates_to_abi(updates);
+    gas = gas.saturating_add(
+        (payload.len() as u64).saturating_mul(UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE),
+    );
+    let zero_bytes = payload.iter().filter(|byte| **byte == 0).count() as u64;
+    let nonzero_bytes = payload.len() as u64 - zero_bytes;
+    let transport = zero_bytes
+        .saturating_mul(CALLDATA_ZERO_BYTE)
+        .saturating_add(nonzero_bytes.saturating_mul(CALLDATA_NONZERO_BYTE));
+
+    let tokens =
+        zero_bytes.saturating_add(nonzero_bytes.saturating_mul(CALLDATA_FLOOR_NONZERO_TOKENS));
+    let floor = TX_BASE.saturating_add(tokens.saturating_mul(CALLDATA_FLOOR_TOKEN));
+
+    gas.saturating_add(transport).max(floor)
 }
 
 /// Enforce the `Unbounded` profile's payload invariant: applying the extracted updates on-chain must
@@ -408,9 +484,16 @@ mod tests {
     fn the_budget_boundary_is_where_arithmetic_says_it_is() {
         // Exactly at the cap passes; one more store does not. Pins the comparison as `>` rather
         // than `>=`, so a payload that precisely fills a transaction is still usable.
-        let per_store = UNBOUNDED_COLD_SSTORE_COST;
-        let room = UNBOUNDED_PAYLOAD_GAS_BUDGET - TX_BASE;
-        let n = (room / per_store) as usize;
+        //
+        // The boundary is found by search rather than division: per-store cost is no longer a
+        // single constant, since transport depends on how the encoded payload's bytes fall.
+        let mut n = 0usize;
+        while check(&(0..n + 1).map(|_| store()).collect::<Vec<_>>()).is_ok() {
+            n += 1;
+            assert!(n < 10_000, "boundary search must terminate");
+        }
+        assert!(n > 0, "at least one store must fit");
+
         let updates: Vec<StateUpdate> = (0..n).map(|_| store()).collect();
         let cost = check(&updates).expect("the largest payload that fits must be accepted");
         assert!(cost.applied_gas_upper_bound <= UNBOUNDED_PAYLOAD_GAS_BUDGET);
@@ -419,6 +502,38 @@ mod tests {
         assert!(
             check(&one_more).is_err(),
             "one store past the cap must fail"
+        );
+    }
+
+    #[test]
+    fn transport_and_dispatch_are_priced_on_top_of_execution() {
+        // The terms this gate exists to not forget. A single store's raw EVM cost is the cold
+        // SSTORE; what a transaction actually pays also includes the bytes that carry it and the
+        // loop that applies it, so the bound must sit strictly above the execution-only figure.
+        let updates = vec![store()];
+        let execution_only = TX_BASE + UNBOUNDED_COLD_SSTORE_COST;
+        let bound = estimate_applied_payload_gas(&updates, 0, 0);
+        assert!(
+            bound > execution_only + UNBOUNDED_APPLY_BASE_GAS,
+            "bound {bound} must exceed execution ({execution_only}) plus the fixed apply cost, \
+             leaving room for the payload's own bytes"
+        );
+
+        // Transport scales with payload bytes: a log carrying data costs more to carry than an
+        // empty one, beyond the 8 gas/byte the LOG opcode itself charges.
+        let empty_log = estimate_applied_payload_gas(&[log1()], 0, 0);
+        let fat_log = estimate_applied_payload_gas(
+            &[StateUpdate::Log1(IStateUpdateTypes::Log1 {
+                data: Bytes::from(vec![0xab; 256]),
+                topic1: B256::ZERO,
+            })],
+            0,
+            0,
+        );
+        assert!(
+            fat_log > empty_log + 256 * 8,
+            "256 data bytes must cost more than the LOG opcode's 8/byte alone: \
+             {fat_log} vs {empty_log}"
         );
     }
 
@@ -459,7 +574,17 @@ mod tests {
     fn empty_payload_is_valid() {
         let cost = check(&[]).unwrap();
         assert_eq!(cost.stores, 0);
-        assert_eq!(cost.applied_gas_upper_bound, TX_BASE);
+        // Not bare `TX_BASE`: an empty payload still encodes two array headers — 128 bytes, being
+        // two offsets and two zero lengths, of which only the offsets' low bytes are non-zero —
+        // and applying it still enters the decode loop. Both are costs a real transaction pays.
+        let transport = 126 * CALLDATA_ZERO_BYTE + 2 * CALLDATA_NONZERO_BYTE;
+        let dispatch = UNBOUNDED_APPLY_BASE_GAS + 128 * UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE;
+        assert_eq!(
+            cost.applied_gas_upper_bound,
+            TX_BASE + transport + dispatch,
+            "an empty payload costs the tx base plus the cost of carrying and decoding two \
+             empty array headers"
+        );
     }
 
     #[test]

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -12,8 +12,8 @@
 //! needed to apply the diff, so a transition may write as many slots as fit
 //! under [`UNBOUNDED_PAYLOAD_GAS_BUDGET`]. Consumers whose state is too large
 //! for that can commit it into fewer slots — in the limit, the single-slot
-//! commitment pattern (solidity-sdk PR #51) — and fan out across contracts via
-//! multi-call forwarding (solidity-sdk PRs #47/#48), but neither is required.
+//! commitment pattern (solidity-sdk PR #51) — but that pattern is an option for
+//! contracts that need it, not a requirement of this mode.
 //!
 //! # Determinism is protocol-critical
 //!
@@ -160,8 +160,8 @@ pub struct UnboundedCost {
     pub tracker_stores: usize,
     /// Number of `Call` ops. These re-execute **on-chain at real gas prices**
     /// when the payload is applied — unbounded compute inside a `Call` is NOT
-    /// killed. Forwarded multi-call sub-payloads (`applyForwardedUpdates`)
-    /// ride in this category by design.
+    /// killed, and is charged against the budget at the gas the trace measured
+    /// for it.
     pub calls: usize,
     /// Number of `Log0`–`Log4` ops.
     pub logs: usize,

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -4,12 +4,16 @@
 //! under. `Chain` mirrors the real chain (today's behaviour everywhere).
 //! `Unbounded` is the Gas Killer *unbounded execution* profile: the tracked
 //! function is simulated with gas limits far above any real block, so
-//! arbitrarily heavy Solidity can be executed off-chain — provided its **net
-//! effect** still fits the Gas Killer on-chain payload shape (at most one
-//! storage write per consumer contract, plus external calls and logs; see
-//! [`validate_unbounded_shape`]). The intended consumer shape is the
-//! single-slot commitment pattern (solidity-sdk PR #51), fanned out across
-//! contracts via multi-call forwarding (solidity-sdk PRs #47/#48).
+//! arbitrarily heavy Solidity can be executed off-chain — provided the payload
+//! it produces still fits in one on-chain transaction (see
+//! [`validate_unbounded_cost`]).
+//!
+//! The constraint is *priced*, not counted: what has to stay bounded is the gas
+//! needed to apply the diff, so a transition may write as many slots as fit
+//! under [`UNBOUNDED_PAYLOAD_GAS_BUDGET`]. Consumers whose state is too large
+//! for that can commit it into fewer slots — in the limit, the single-slot
+//! commitment pattern (solidity-sdk PR #51) — and fan out across contracts via
+//! multi-call forwarding (solidity-sdk PRs #47/#48), but neither is required.
 //!
 //! # Determinism is protocol-critical
 //!
@@ -48,7 +52,7 @@ use alloy_primitives::{B256, b256};
 /// extracted diff carries a Store to this slot; `verifyAndUpdate`'s own
 /// modifier writes the same value on-chain, making the payload copy
 /// idempotent. It is a fixed protocol slot — one per consumer regardless of
-/// state size — and is therefore exempt from the single-slot shape count.
+/// state size — so it is reported separately from the consumer's own writes.
 pub const STATE_TRACKER_SLOT: B256 =
     b256!("0xdebfdfd5a50ad117c10898d68b5ccf0893c6b40d4f443f902e2e7646601bdeaf");
 
@@ -79,8 +83,8 @@ pub enum SimProfile {
     #[default]
     Chain,
     /// Gas Killer unbounded execution: simulate with
-    /// [`UNBOUNDED_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_TX_GAS_LIMIT`] and
-    /// enforce the single-slot payload shape on the extracted updates.
+    /// [`UNBOUNDED_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_TX_GAS_LIMIT`] and require the
+    /// extracted payload to cost no more than [`UNBOUNDED_PAYLOAD_GAS_BUDGET`] to apply.
     Unbounded,
 }
 
@@ -101,16 +105,56 @@ impl SimProfile {
         }
     }
 
-    /// Whether extracted updates must satisfy [`validate_unbounded_shape`].
-    pub fn requires_unbounded_shape(&self) -> bool {
-        matches!(self, SimProfile::Unbounded)
+    /// The ceiling this profile places on the on-chain cost of the extracted payload, if any.
+    ///
+    /// `Chain` needs none: the simulation ran under the real chain's limits, so anything it produced
+    /// was already affordable there. `Unbounded` lifts those limits for the simulation and therefore
+    /// has to reimpose a bound on the result — see [`validate_unbounded_cost`].
+    pub fn payload_gas_budget(&self) -> Option<u64> {
+        match self {
+            SimProfile::Chain => None,
+            SimProfile::Unbounded => Some(UNBOUNDED_PAYLOAD_GAS_BUDGET),
+        }
     }
 }
 
-/// Summary of a payload that passed [`validate_unbounded_shape`].
+/// Ceiling on the on-chain cost of an extracted payload under the `Unbounded` profile: EIP-7825's
+/// per-transaction gas cap, `2^24`.
+///
+/// This is the protocol's own maximum for a single transaction, so a payload priced above it can
+/// never be applied by `verifyAndUpdate` on a post-Osaka chain no matter how empty the block is. The
+/// profile therefore *lifts* EIP-7825 for the off-chain simulation, where the cap protects nothing,
+/// and *enforces* it on the payload, where it is binding. Picking the protocol limit rather than a
+/// tuned number also keeps this from becoming a knob: like the gas limits above it is a pinned
+/// constant, and changing it changes which payloads honest operators accept.
+pub const UNBOUNDED_PAYLOAD_GAS_BUDGET: u64 = 1 << 24;
+
+/// Worst-case cost charged per `Store` by [`estimate_applied_payload_gas`]: EIP-2929 cold SLOAD
+/// (2100) plus a zero→nonzero `SSTORE` (20000).
+///
+/// Deliberately *not* shared with `crate::heuristic`'s reporting estimator. That one approximates
+/// the typical cost to produce user-facing savings figures and is tuned over time; this one must be
+/// a stable upper bound, because it decides which payloads are valid. If the two shared a
+/// definition, tuning a displayed number would silently change what operators accept — and a gate
+/// that under-prices a write accepts payloads that do not actually fit.
+pub const UNBOUNDED_COLD_SSTORE_COST: u64 = 22_100;
+
+/// The gate must never price a write below the reporting heuristic: that one models a *typical*
+/// warm write, and a gate charging less than typical would admit payloads that do not fit.
+const _: () = assert!(UNBOUNDED_COLD_SSTORE_COST > crate::heuristic::WARM_SSTORE_COST);
+
+/// Cost of a `LOG*` op: base, plus per topic, plus per byte of data.
+const LOG_BASE: u64 = 375;
+const LOG_TOPIC: u64 = 375;
+const LOG_BYTE: u64 = 8;
+
+/// Intrinsic cost of the `verifyAndUpdate` transaction that carries the payload.
+const TX_BASE: u64 = 21_000;
+
+/// Summary of a payload that passed [`validate_unbounded_cost`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UnboundedShape {
-    /// Number of `Store` ops other than the [`STATE_TRACKER_SLOT`] (0 or 1).
+pub struct UnboundedCost {
+    /// Number of `Store` ops other than the [`STATE_TRACKER_SLOT`].
     pub stores: usize,
     /// Number of `Store` ops to the fixed [`STATE_TRACKER_SLOT`] (0 or 1).
     pub tracker_stores: usize,
@@ -121,91 +165,148 @@ pub struct UnboundedShape {
     pub calls: usize,
     /// Number of `Log0`–`Log4` ops.
     pub logs: usize,
+    /// Upper bound on the gas needed to apply this payload on-chain, including the transaction's
+    /// intrinsic cost and the signature-verification floor.
+    pub applied_gas_upper_bound: u64,
 }
 
 /// Why a payload is not valid under the unbounded profile.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum UnboundedShapeViolation {
-    /// More than one storage write. The unbounded profile exists precisely
-    /// because compute is unbounded while *state* stays O(1): a consumer that
-    /// writes N slots per transition pays N cold SSTOREs on-chain and scales
-    /// like a plain contract. Restructure the consumer around a single-slot
-    /// commitment (solidity-sdk PR #51) instead.
-    TooManyStores {
-        /// Total `Store` ops found.
-        count: usize,
+pub enum UnboundedCostViolation {
+    /// Applying the payload costs more than [`UNBOUNDED_PAYLOAD_GAS_BUDGET`].
+    ///
+    /// The unbounded profile's bargain is that *compute* may be unbounded while the payload that
+    /// lands on-chain still fits in one transaction. A consumer that writes enough slots to exceed
+    /// the cap has not moved work off-chain — it has moved it into a transaction nobody can mine.
+    /// Either reduce the state each transition touches, or commit it into fewer slots (for the
+    /// extreme case, the single-slot commitment pattern in solidity-sdk PR #51).
+    PayloadTooExpensive {
+        /// Upper-bound gas to apply the payload.
+        estimated: u64,
+        /// The ceiling it exceeded.
+        budget: u64,
+        /// Non-tracker `Store` ops, the usual driver when this trips.
+        stores: usize,
     },
-    /// `CREATE`/`CREATE2` found. Initcode replays on-chain inside
-    /// `verifyAndUpdate` at real gas prices, so a deployment produced by an
-    /// unbounded simulation may simply not fit in a real block; the struct-log
-    /// path also cannot reconstruct replayable initcode from a net diff.
+    /// `CREATE`/`CREATE2` found. Not a cost question: the struct-log path extracts a
+    /// `Create`/`Create2` op carrying initcode to re-execute on replay, and a net diff cannot
+    /// reconstruct that, so contract creation is unrepresentable here regardless of price.
     CreateNotAllowed {
         /// Index of the offending op in the update list.
         index: usize,
     },
 }
 
-impl core::fmt::Display for UnboundedShapeViolation {
+impl core::fmt::Display for UnboundedCostViolation {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            UnboundedShapeViolation::TooManyStores { count } => write!(
+            UnboundedCostViolation::PayloadTooExpensive {
+                estimated,
+                budget,
+                stores,
+            } => write!(
                 f,
-                "unbounded profile requires at most one storage write per consumer \
-                 (single-slot commitment pattern), found {count} Store ops; \
-                 restructure the consumer to commit its state into one slot"
+                "unbounded payload costs up to {estimated} gas to apply, over the {budget} budget \
+                 ({stores} storage writes); reduce the state each transition touches or commit it \
+                 into fewer slots"
             ),
-            UnboundedShapeViolation::CreateNotAllowed { index } => write!(
+            UnboundedCostViolation::CreateNotAllowed { index } => write!(
                 f,
-                "unbounded profile does not allow CREATE/CREATE2 (update #{index}): \
-                 initcode replays on-chain at real gas prices and may not fit a real block"
+                "unbounded profile does not allow CREATE/CREATE2 (update #{index}): a net diff \
+                 cannot reconstruct replayable initcode"
             ),
         }
     }
 }
 
-impl std::error::Error for UnboundedShapeViolation {}
+impl std::error::Error for UnboundedCostViolation {}
 
-/// Enforce the `Unbounded` payload-shape invariant on extracted updates:
-/// at most one `Store` beyond the fixed [`STATE_TRACKER_SLOT`] (which every
-/// `trackState` diff carries), no `CREATE`/`CREATE2`; `Call`/`Log*` ops pass.
+/// Upper bound on the gas required to apply `updates` on-chain via `verifyAndUpdate`.
 ///
-/// This is what makes "play fast and loose with the gas limit" sound: the
-/// simulation may burn a terabyte of gas, but the thing that lands on-chain
-/// is provably one SSTORE plus bounded calls/logs. A violation means the
-/// consumer contract is not commitment-shaped — failing loudly here beats
-/// signing a payload whose on-chain application costs O(slots touched).
-pub fn validate_unbounded_shape(
+/// `external_call_gas` is the measured cost of the payload's `Call` ops, taken from the trace — they
+/// re-execute on-chain at real prices, so they are charged at what they actually cost rather than
+/// estimated. `signature_floor` is the scheme's verification cost
+/// (`SignatureType::turetzky_upper_gas_limit`); pass the larger scheme's when the scheme is not yet
+/// known, since the payload is signed independently of it.
+///
+/// A pure function of its arguments, which is the point: it decides whether a payload is acceptable,
+/// so every operator must reach the same verdict from the same payload. Anything that consulted live
+/// chain state could put two honest operators on opposite sides of the boundary.
+pub fn estimate_applied_payload_gas(
     updates: &[StateUpdate],
-) -> Result<UnboundedShape, UnboundedShapeViolation> {
-    let mut shape = UnboundedShape {
+    external_call_gas: u64,
+    signature_floor: u64,
+) -> u64 {
+    let mut gas = TX_BASE
+        .saturating_add(signature_floor)
+        .saturating_add(external_call_gas);
+    for update in updates {
+        gas = gas.saturating_add(match update {
+            StateUpdate::Store(_) => UNBOUNDED_COLD_SSTORE_COST,
+            // Charged through `external_call_gas` from the trace.
+            StateUpdate::Call(_) => 0,
+            StateUpdate::Log0(l) => LOG_BASE + l.data.len() as u64 * LOG_BYTE,
+            StateUpdate::Log1(l) => LOG_BASE + LOG_TOPIC + l.data.len() as u64 * LOG_BYTE,
+            StateUpdate::Log2(l) => LOG_BASE + LOG_TOPIC * 2 + l.data.len() as u64 * LOG_BYTE,
+            StateUpdate::Log3(l) => LOG_BASE + LOG_TOPIC * 3 + l.data.len() as u64 * LOG_BYTE,
+            StateUpdate::Log4(l) => LOG_BASE + LOG_TOPIC * 4 + l.data.len() as u64 * LOG_BYTE,
+            // Rejected by the caller; priced at zero so the bound stays defined either way.
+            StateUpdate::Create(_) | StateUpdate::Create2(_) => 0,
+        });
+    }
+    gas
+}
+
+/// Enforce the `Unbounded` profile's payload invariant: applying the extracted updates on-chain must
+/// cost no more than `budget`, and must not contain `CREATE`/`CREATE2`.
+///
+/// This is what makes lifting the simulation gas limit sound. The simulation may burn a terabyte of
+/// gas; what lands on-chain still has to fit in a single transaction, so the constraint is priced
+/// rather than counted. Writing many slots is fine — writing more than fits is not.
+///
+/// The [`STATE_TRACKER_SLOT`] is counted in the cost (it is a real write) but reported separately,
+/// since every `trackState` diff carries exactly one and `verifyAndUpdate`'s own modifier rewrites
+/// it idempotently.
+pub fn validate_unbounded_cost(
+    updates: &[StateUpdate],
+    external_call_gas: u64,
+    signature_floor: u64,
+    budget: u64,
+) -> Result<UnboundedCost, UnboundedCostViolation> {
+    let mut cost = UnboundedCost {
         stores: 0,
         tracker_stores: 0,
         calls: 0,
         logs: 0,
+        applied_gas_upper_bound: 0,
     };
     for (index, update) in updates.iter().enumerate() {
         match update {
             StateUpdate::Store(store) if store.slot == STATE_TRACKER_SLOT => {
-                shape.tracker_stores += 1
+                cost.tracker_stores += 1
             }
-            StateUpdate::Store(_) => shape.stores += 1,
-            StateUpdate::Call(_) => shape.calls += 1,
+            StateUpdate::Store(_) => cost.stores += 1,
+            StateUpdate::Call(_) => cost.calls += 1,
             StateUpdate::Log0(_)
             | StateUpdate::Log1(_)
             | StateUpdate::Log2(_)
             | StateUpdate::Log3(_)
-            | StateUpdate::Log4(_) => shape.logs += 1,
+            | StateUpdate::Log4(_) => cost.logs += 1,
             StateUpdate::Create(_) | StateUpdate::Create2(_) => {
-                return Err(UnboundedShapeViolation::CreateNotAllowed { index });
+                return Err(UnboundedCostViolation::CreateNotAllowed { index });
             }
         }
     }
-    if shape.stores > 1 {
-        return Err(UnboundedShapeViolation::TooManyStores {
-            count: shape.stores,
+    cost.applied_gas_upper_bound =
+        estimate_applied_payload_gas(updates, external_call_gas, signature_floor);
+    if cost.applied_gas_upper_bound > budget {
+        return Err(UnboundedCostViolation::PayloadTooExpensive {
+            estimated: cost.applied_gas_upper_bound,
+            budget,
+            stores: cost.stores,
         });
     }
-    Ok(shape)
+    Ok(cost)
 }
 
 #[cfg(test)]
@@ -243,11 +344,16 @@ mod tests {
         })
     }
 
+    /// Budget with no signature floor and no call gas, so tests price only the payload ops.
+    fn check(updates: &[StateUpdate]) -> Result<UnboundedCost, UnboundedCostViolation> {
+        validate_unbounded_cost(updates, 0, 0, UNBOUNDED_PAYLOAD_GAS_BUDGET)
+    }
+
     #[test]
     fn chain_profile_overrides_nothing() {
         assert_eq!(SimProfile::Chain.tx_gas_limit_override(), None);
         assert_eq!(SimProfile::Chain.block_gas_limit_override(), None);
-        assert!(!SimProfile::Chain.requires_unbounded_shape());
+        assert_eq!(SimProfile::Chain.payload_gas_budget(), None);
         assert_eq!(SimProfile::default(), SimProfile::Chain);
     }
 
@@ -261,71 +367,119 @@ mod tests {
             SimProfile::Unbounded.block_gas_limit_override(),
             Some(UNBOUNDED_BLOCK_GAS_LIMIT)
         );
-        assert!(SimProfile::Unbounded.requires_unbounded_shape());
+        assert_eq!(
+            SimProfile::Unbounded.payload_gas_budget(),
+            Some(UNBOUNDED_PAYLOAD_GAS_BUDGET)
+        );
         // The constants are protocol-pinned: a change here is a consensus
         // break with the SP1 slashing guest and must ship as a new version.
         assert_eq!(UNBOUNDED_BLOCK_GAS_LIMIT, 1 << 40);
         assert_eq!(UNBOUNDED_TX_GAS_LIMIT, 1 << 40);
+        // EIP-7825's per-transaction cap — the ceiling a payload must fit under.
+        assert_eq!(UNBOUNDED_PAYLOAD_GAS_BUDGET, 1 << 24);
+    }
+
+    #[test]
+    fn many_stores_are_valid_while_they_fit() {
+        // The point of pricing rather than counting: a consumer that writes far more than one slot
+        // is fine, because the payload still fits in a transaction.
+        let updates: Vec<StateUpdate> = (0..500).map(|_| store()).collect();
+        let cost = check(&updates).expect("500 writes fit under the cap");
+        assert_eq!(cost.stores, 500);
+        assert!(cost.applied_gas_upper_bound < UNBOUNDED_PAYLOAD_GAS_BUDGET);
+    }
+
+    #[test]
+    fn a_payload_over_the_budget_is_rejected() {
+        let n = (UNBOUNDED_PAYLOAD_GAS_BUDGET / UNBOUNDED_COLD_SSTORE_COST) as usize + 2;
+        let updates: Vec<StateUpdate> = (0..n).map(|_| store()).collect();
+        let err = check(&updates).unwrap_err();
+        let UnboundedCostViolation::PayloadTooExpensive {
+            estimated, budget, ..
+        } = err
+        else {
+            panic!("expected PayloadTooExpensive, got {err:?}");
+        };
+        assert!(estimated > budget);
+        assert!(err.to_string().contains("over the"));
+    }
+
+    #[test]
+    fn the_budget_boundary_is_where_arithmetic_says_it_is() {
+        // Exactly at the cap passes; one more store does not. Pins the comparison as `>` rather
+        // than `>=`, so a payload that precisely fills a transaction is still usable.
+        let per_store = UNBOUNDED_COLD_SSTORE_COST;
+        let room = UNBOUNDED_PAYLOAD_GAS_BUDGET - TX_BASE;
+        let n = (room / per_store) as usize;
+        let updates: Vec<StateUpdate> = (0..n).map(|_| store()).collect();
+        let cost = check(&updates).expect("the largest payload that fits must be accepted");
+        assert!(cost.applied_gas_upper_bound <= UNBOUNDED_PAYLOAD_GAS_BUDGET);
+
+        let one_more: Vec<StateUpdate> = (0..n + 1).map(|_| store()).collect();
+        assert!(
+            check(&one_more).is_err(),
+            "one store past the cap must fail"
+        );
+    }
+
+    #[test]
+    fn the_signature_floor_and_call_gas_count_against_the_budget() {
+        // A payload that fits on its own can be pushed over by what rides with it on-chain.
+        let updates = vec![store()];
+        assert!(
+            validate_unbounded_cost(&updates, 0, 250_000, UNBOUNDED_PAYLOAD_GAS_BUDGET).is_ok()
+        );
+        assert!(
+            validate_unbounded_cost(
+                &updates,
+                UNBOUNDED_PAYLOAD_GAS_BUDGET,
+                250_000,
+                UNBOUNDED_PAYLOAD_GAS_BUDGET
+            )
+            .is_err(),
+            "external call gas is real on-chain cost and must count"
+        );
     }
 
     #[test]
     fn single_store_with_calls_and_logs_is_valid() {
         let updates = vec![call(), store(), log1(), call(), log1()];
-        let shape = validate_unbounded_shape(&updates).unwrap();
-        assert_eq!(
-            shape,
-            UnboundedShape {
-                stores: 1,
-                tracker_stores: 0,
-                calls: 2,
-                logs: 2
-            }
-        );
+        let cost = check(&updates).unwrap();
+        assert_eq!(cost.stores, 1);
+        assert_eq!(cost.calls, 2);
+        assert_eq!(cost.logs, 2);
     }
 
     #[test]
     fn zero_stores_is_valid() {
-        let shape = validate_unbounded_shape(&[call(), log1()]).unwrap();
-        assert_eq!(shape.stores, 0);
+        assert_eq!(check(&[call(), log1()]).unwrap().stores, 0);
     }
 
     #[test]
     fn empty_payload_is_valid() {
-        let shape = validate_unbounded_shape(&[]).unwrap();
-        assert_eq!(
-            shape,
-            UnboundedShape {
-                stores: 0,
-                tracker_stores: 0,
-                calls: 0,
-                logs: 0
-            }
-        );
+        let cost = check(&[]).unwrap();
+        assert_eq!(cost.stores, 0);
+        assert_eq!(cost.applied_gas_upper_bound, TX_BASE);
     }
 
     #[test]
-    fn tracker_slot_store_is_exempt() {
+    fn tracker_slot_store_is_counted_but_reported_separately() {
         // The realistic trackState diff: counter bump + one commitment write + log.
         let tracker = StateUpdate::Store(IStateUpdateTypes::Store {
             slot: STATE_TRACKER_SLOT,
             value: B256::with_last_byte(1),
         });
-        let shape = validate_unbounded_shape(&[tracker, store(), log1()]).unwrap();
-        assert_eq!(shape.stores, 1);
-        assert_eq!(shape.tracker_stores, 1);
-    }
-
-    #[test]
-    fn two_stores_is_rejected() {
-        let err = validate_unbounded_shape(&[store(), log1(), store()]).unwrap_err();
-        assert_eq!(err, UnboundedShapeViolation::TooManyStores { count: 2 });
-        assert!(err.to_string().contains("single-slot commitment"));
+        let cost = check(&[tracker, store(), log1()]).unwrap();
+        assert_eq!(cost.stores, 1);
+        assert_eq!(cost.tracker_stores, 1);
+        // It is a real write, so it is priced even though it is not counted in `stores`.
+        assert!(cost.applied_gas_upper_bound >= TX_BASE + 2 * UNBOUNDED_COLD_SSTORE_COST);
     }
 
     #[test]
     fn create_is_rejected_at_index() {
-        let err = validate_unbounded_shape(&[store(), create()]).unwrap_err();
-        assert_eq!(err, UnboundedShapeViolation::CreateNotAllowed { index: 1 });
+        let err = check(&[store(), create()]).unwrap_err();
+        assert_eq!(err, UnboundedCostViolation::CreateNotAllowed { index: 1 });
     }
 
     #[test]
@@ -335,10 +489,10 @@ mod tests {
             value: U256::ZERO,
             initcode: Bytes::new(),
         });
-        let err = validate_unbounded_shape(&[update]).unwrap_err();
+        let err = check(&[update]).unwrap_err();
         assert!(matches!(
             err,
-            UnboundedShapeViolation::CreateNotAllowed { index: 0 }
+            UnboundedCostViolation::CreateNotAllowed { index: 0 }
         ));
     }
 }

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -1,0 +1,344 @@
+//! Simulation environment profiles for Gas Killer execution.
+//!
+//! A [`SimProfile`] pins the EVM environment a tracked function is simulated
+//! under. `Chain` mirrors the real chain (today's behaviour everywhere).
+//! `Unbounded` is the Gas Killer *unbounded execution* profile: the tracked
+//! function is simulated with gas limits far above any real block, so
+//! arbitrarily heavy Solidity can be executed off-chain — provided its **net
+//! effect** still fits the Gas Killer on-chain payload shape (at most one
+//! storage write per consumer contract, plus external calls and logs; see
+//! [`validate_unbounded_shape`]). The intended consumer shape is the
+//! single-slot commitment pattern (solidity-sdk PR #51), fanned out across
+//! contracts via multi-call forwarding (solidity-sdk PRs #47/#48).
+//!
+//! # Determinism is protocol-critical
+//!
+//! The profile's limits are **pinned protocol constants**, not tunables.
+//! Every party that re-executes a tracked function must use bit-identical
+//! environment overrides:
+//!
+//! 1. operators, when extracting the state-update payload they sign;
+//! 2. this analyzer, when simulating on a user's behalf;
+//! 3. the SP1 slashing guest (`docs/SP1_REVM_IMPLEMENTATION_SPEC.md`), when a
+//!    slasher re-executes the original function inside the zkVM to prove the
+//!    signed updates wrong.
+//!
+//! If the guest ran with the real header's `gas_limit` while operators
+//! simulated under lifted limits, a heavy-but-honest execution would OOG in
+//! the guest and produce a *different* update set — falsely slashing honest
+//! operators. Conversely, per-operator ad-hoc limits would make quorum
+//! signatures diverge on the boundary. So the constants below are a pinned
+//! protocol value, not a tuning knob: changing them changes what honest
+//! operators produce, and must be rolled out fleet-wide in lockstep with the
+//! slashing guest — never as a silent edit.
+//!
+//! Calldata note: neither revm nor the EVM protocol caps calldata *size*;
+//! calldata is bounded only through intrinsic gas (EIP-7623 floor pricing).
+//! Lifting the gas limits therefore lifts the effective calldata bound too —
+//! multi-megabyte witnesses (e.g. the expanded state behind a single-slot
+//! commitment) simulate fine under `Unbounded` even though they could never
+//! land in a real transaction. Only the *signed payload* must fit on-chain.
+
+use crate::types::StateUpdate;
+use alloy_primitives::{B256, b256};
+
+/// The Gas Killer SDK's `StateTracker` transition-counter slot
+/// (`keccak256("gasKiller.stateTracker") - 1`, see solidity-sdk
+/// `StateTracker.sol`). Every `trackState` function bumps it, so every
+/// extracted diff carries a Store to this slot; `verifyAndUpdate`'s own
+/// modifier writes the same value on-chain, making the payload copy
+/// idempotent. It is a fixed protocol slot — one per consumer regardless of
+/// state size — and is therefore exempt from the single-slot shape count.
+pub const STATE_TRACKER_SLOT: B256 =
+    b256!("0xdebfdfd5a50ad117c10898d68b5ccf0893c6b40d4f443f902e2e7646601bdeaf");
+
+/// Block gas limit for the `Unbounded` profile: 2^40 ≈ 1.1 Tgas,
+/// ~24,000× a 45M-gas mainnet block.
+///
+/// Chosen instead of `u64::MAX` so intrinsic-gas / refund / floor-cost
+/// arithmetic (all `u64` in revm and in geth's tracer path) cannot overflow,
+/// while still admitting ~27 GB of EIP-7623-priced calldata — far beyond any
+/// realistic witness.
+pub const UNBOUNDED_BLOCK_GAS_LIMIT: u64 = 1 << 40;
+
+/// Transaction gas limit for the `Unbounded` profile.
+///
+/// Equal to the block limit: the profile deliberately ignores the EIP-7825
+/// per-transaction cap (2^24) — that cap protects real block building and has
+/// no purpose in an off-chain simulation whose result is applied on-chain as
+/// a Gas Killer payload.
+pub const UNBOUNDED_TX_GAS_LIMIT: u64 = UNBOUNDED_BLOCK_GAS_LIMIT;
+
+/// The EVM environment profile a tracked function is simulated under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SimProfile {
+    /// Mirror the anchored chain's real environment (header gas limit,
+    /// EIP-7825 tx cap where active). This is the historical behaviour and
+    /// the right profile whenever the analyzed call must also be *executable*
+    /// on-chain as-is.
+    #[default]
+    Chain,
+    /// Gas Killer unbounded execution: simulate with
+    /// [`UNBOUNDED_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_TX_GAS_LIMIT`] and
+    /// enforce the single-slot payload shape on the extracted updates.
+    Unbounded,
+}
+
+impl SimProfile {
+    /// Transaction-level gas limit override, if this profile lifts it.
+    pub fn tx_gas_limit_override(&self) -> Option<u64> {
+        match self {
+            SimProfile::Chain => None,
+            SimProfile::Unbounded => Some(UNBOUNDED_TX_GAS_LIMIT),
+        }
+    }
+
+    /// Block-level gas limit override, if this profile lifts it.
+    pub fn block_gas_limit_override(&self) -> Option<u64> {
+        match self {
+            SimProfile::Chain => None,
+            SimProfile::Unbounded => Some(UNBOUNDED_BLOCK_GAS_LIMIT),
+        }
+    }
+
+    /// Whether extracted updates must satisfy [`validate_unbounded_shape`].
+    pub fn requires_unbounded_shape(&self) -> bool {
+        matches!(self, SimProfile::Unbounded)
+    }
+}
+
+/// Summary of a payload that passed [`validate_unbounded_shape`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnboundedShape {
+    /// Number of `Store` ops other than the [`STATE_TRACKER_SLOT`] (0 or 1).
+    pub stores: usize,
+    /// Number of `Store` ops to the fixed [`STATE_TRACKER_SLOT`] (0 or 1).
+    pub tracker_stores: usize,
+    /// Number of `Call` ops. These re-execute **on-chain at real gas prices**
+    /// when the payload is applied — unbounded compute inside a `Call` is NOT
+    /// killed. Forwarded multi-call sub-payloads (`applyForwardedUpdates`)
+    /// ride in this category by design.
+    pub calls: usize,
+    /// Number of `Log0`–`Log4` ops.
+    pub logs: usize,
+}
+
+/// Why a payload is not valid under the unbounded profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnboundedShapeViolation {
+    /// More than one storage write. The unbounded profile exists precisely
+    /// because compute is unbounded while *state* stays O(1): a consumer that
+    /// writes N slots per transition pays N cold SSTOREs on-chain and scales
+    /// like a plain contract. Restructure the consumer around a single-slot
+    /// commitment (solidity-sdk PR #51) instead.
+    TooManyStores {
+        /// Total `Store` ops found.
+        count: usize,
+    },
+    /// `CREATE`/`CREATE2` found. Initcode replays on-chain inside
+    /// `verifyAndUpdate` at real gas prices, so a deployment produced by an
+    /// unbounded simulation may simply not fit in a real block; the struct-log
+    /// path also cannot reconstruct replayable initcode from a net diff.
+    CreateNotAllowed {
+        /// Index of the offending op in the update list.
+        index: usize,
+    },
+}
+
+impl core::fmt::Display for UnboundedShapeViolation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UnboundedShapeViolation::TooManyStores { count } => write!(
+                f,
+                "unbounded profile requires at most one storage write per consumer \
+                 (single-slot commitment pattern), found {count} Store ops; \
+                 restructure the consumer to commit its state into one slot"
+            ),
+            UnboundedShapeViolation::CreateNotAllowed { index } => write!(
+                f,
+                "unbounded profile does not allow CREATE/CREATE2 (update #{index}): \
+                 initcode replays on-chain at real gas prices and may not fit a real block"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UnboundedShapeViolation {}
+
+/// Enforce the `Unbounded` payload-shape invariant on extracted updates:
+/// at most one `Store` beyond the fixed [`STATE_TRACKER_SLOT`] (which every
+/// `trackState` diff carries), no `CREATE`/`CREATE2`; `Call`/`Log*` ops pass.
+///
+/// This is what makes "play fast and loose with the gas limit" sound: the
+/// simulation may burn a terabyte of gas, but the thing that lands on-chain
+/// is provably one SSTORE plus bounded calls/logs. A violation means the
+/// consumer contract is not commitment-shaped — failing loudly here beats
+/// signing a payload whose on-chain application costs O(slots touched).
+pub fn validate_unbounded_shape(
+    updates: &[StateUpdate],
+) -> Result<UnboundedShape, UnboundedShapeViolation> {
+    let mut shape = UnboundedShape {
+        stores: 0,
+        tracker_stores: 0,
+        calls: 0,
+        logs: 0,
+    };
+    for (index, update) in updates.iter().enumerate() {
+        match update {
+            StateUpdate::Store(store) if store.slot == STATE_TRACKER_SLOT => {
+                shape.tracker_stores += 1
+            }
+            StateUpdate::Store(_) => shape.stores += 1,
+            StateUpdate::Call(_) => shape.calls += 1,
+            StateUpdate::Log0(_)
+            | StateUpdate::Log1(_)
+            | StateUpdate::Log2(_)
+            | StateUpdate::Log3(_)
+            | StateUpdate::Log4(_) => shape.logs += 1,
+            StateUpdate::Create(_) | StateUpdate::Create2(_) => {
+                return Err(UnboundedShapeViolation::CreateNotAllowed { index });
+            }
+        }
+    }
+    if shape.stores > 1 {
+        return Err(UnboundedShapeViolation::TooManyStores {
+            count: shape.stores,
+        });
+    }
+    Ok(shape)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::IStateUpdateTypes;
+    use alloy_primitives::{Address, Bytes, U256};
+
+    fn store() -> StateUpdate {
+        StateUpdate::Store(IStateUpdateTypes::Store {
+            slot: B256::ZERO,
+            value: B256::ZERO,
+        })
+    }
+
+    fn call() -> StateUpdate {
+        StateUpdate::Call(IStateUpdateTypes::Call {
+            target: Address::ZERO,
+            value: U256::ZERO,
+            callargs: Bytes::new(),
+        })
+    }
+
+    fn log1() -> StateUpdate {
+        StateUpdate::Log1(IStateUpdateTypes::Log1 {
+            data: Bytes::new(),
+            topic1: B256::ZERO,
+        })
+    }
+
+    fn create() -> StateUpdate {
+        StateUpdate::Create(IStateUpdateTypes::Create {
+            value: U256::ZERO,
+            initcode: Bytes::new(),
+        })
+    }
+
+    #[test]
+    fn chain_profile_overrides_nothing() {
+        assert_eq!(SimProfile::Chain.tx_gas_limit_override(), None);
+        assert_eq!(SimProfile::Chain.block_gas_limit_override(), None);
+        assert!(!SimProfile::Chain.requires_unbounded_shape());
+        assert_eq!(SimProfile::default(), SimProfile::Chain);
+    }
+
+    #[test]
+    fn unbounded_profile_pins_its_constants() {
+        assert_eq!(
+            SimProfile::Unbounded.tx_gas_limit_override(),
+            Some(UNBOUNDED_TX_GAS_LIMIT)
+        );
+        assert_eq!(
+            SimProfile::Unbounded.block_gas_limit_override(),
+            Some(UNBOUNDED_BLOCK_GAS_LIMIT)
+        );
+        assert!(SimProfile::Unbounded.requires_unbounded_shape());
+        // The constants are protocol-pinned: a change here is a consensus
+        // break with the SP1 slashing guest and must ship as a new version.
+        assert_eq!(UNBOUNDED_BLOCK_GAS_LIMIT, 1 << 40);
+        assert_eq!(UNBOUNDED_TX_GAS_LIMIT, 1 << 40);
+    }
+
+    #[test]
+    fn single_store_with_calls_and_logs_is_valid() {
+        let updates = vec![call(), store(), log1(), call(), log1()];
+        let shape = validate_unbounded_shape(&updates).unwrap();
+        assert_eq!(
+            shape,
+            UnboundedShape {
+                stores: 1,
+                tracker_stores: 0,
+                calls: 2,
+                logs: 2
+            }
+        );
+    }
+
+    #[test]
+    fn zero_stores_is_valid() {
+        let shape = validate_unbounded_shape(&[call(), log1()]).unwrap();
+        assert_eq!(shape.stores, 0);
+    }
+
+    #[test]
+    fn empty_payload_is_valid() {
+        let shape = validate_unbounded_shape(&[]).unwrap();
+        assert_eq!(
+            shape,
+            UnboundedShape {
+                stores: 0,
+                tracker_stores: 0,
+                calls: 0,
+                logs: 0
+            }
+        );
+    }
+
+    #[test]
+    fn tracker_slot_store_is_exempt() {
+        // The realistic trackState diff: counter bump + one commitment write + log.
+        let tracker = StateUpdate::Store(IStateUpdateTypes::Store {
+            slot: STATE_TRACKER_SLOT,
+            value: B256::with_last_byte(1),
+        });
+        let shape = validate_unbounded_shape(&[tracker, store(), log1()]).unwrap();
+        assert_eq!(shape.stores, 1);
+        assert_eq!(shape.tracker_stores, 1);
+    }
+
+    #[test]
+    fn two_stores_is_rejected() {
+        let err = validate_unbounded_shape(&[store(), log1(), store()]).unwrap_err();
+        assert_eq!(err, UnboundedShapeViolation::TooManyStores { count: 2 });
+        assert!(err.to_string().contains("single-slot commitment"));
+    }
+
+    #[test]
+    fn create_is_rejected_at_index() {
+        let err = validate_unbounded_shape(&[store(), create()]).unwrap_err();
+        assert_eq!(err, UnboundedShapeViolation::CreateNotAllowed { index: 1 });
+    }
+
+    #[test]
+    fn create2_is_rejected() {
+        let update = StateUpdate::Create2(IStateUpdateTypes::Create2 {
+            salt: B256::ZERO,
+            value: U256::ZERO,
+            initcode: Bytes::new(),
+        });
+        let err = validate_unbounded_shape(&[update]).unwrap_err();
+        assert!(matches!(
+            err,
+            UnboundedShapeViolation::CreateNotAllowed { index: 0 }
+        ));
+    }
+}

--- a/crates/evmsketch/Cargo.toml
+++ b/crates/evmsketch/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2024"
 
 [features]
 heap-profile = []
-# Enables the anvil-backed integration tests, which spawn a local `anvil` and so require foundry on
-# PATH. Off by default so a plain `cargo test` needs no external tooling.
-anvil = []
 
 [dependencies]
 alloy = { version = "1.0.37", features = ["rpc", "rpc-types"] }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -115,10 +115,10 @@ use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 pub use gas_analyzer_core::SimProfile;
 
 use gas_analyzer_core::{
-    Opcode, PrestateEligibility, StateUpdate, build_state_updates_from_prestate,
+    Opcode, PrestateEligibility, SignatureType, StateUpdate, build_state_updates_from_prestate,
     classify_prestate_eligibility, compute_state_updates, compute_state_updates_canonical,
     encode_state_updates_to_abi, estimate_gas_from_operations, extract_operation_counts_from_trace,
-    validate_unbounded_shape,
+    validate_unbounded_cost,
 };
 use gas_analyzer_estimator::{PrecedingTx, SimEnvOpts};
 use gas_analyzer_rpc::{
@@ -889,9 +889,9 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_mode(
 ///
 /// Under [`SimProfile::Unbounded`] the call is simulated with the pinned unbounded gas limits
 /// (`gas_analyzer_core::sim_profile`) so arbitrarily heavy compute can execute off-chain, and the
-/// extracted updates must pass [`validate_unbounded_shape`] (at most one `Store`, no `CREATE`) — a
-/// violation is a hard error, because a payload that writes N slots scales on-chain like a plain
-/// contract and defeats the mode's purpose.
+/// extracted updates must pass [`validate_unbounded_cost`]: applying the payload on-chain must cost
+/// no more than the profile's budget, and it must contain no `CREATE`. A violation is a hard error —
+/// signing a payload that cannot be mined produces a task nobody can settle.
 ///
 /// Two things intentionally stay on the real chain's environment:
 /// - the **gas estimate** for applying the payload (`verifyAndUpdate` lands in a real block, so it
@@ -944,7 +944,7 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
     // Extract the state updates (hybrid prestate/struct-log path) and build the executor
     // concurrently — they are independent, so on a cache miss this hides the executor build behind
     // the trace fetch.
-    let ((state_updates, skipped_opcodes), executor) = tokio::try_join!(
+    let ((state_updates, skipped_opcodes, call_gas_total), executor) = tokio::try_join!(
         extract_state_updates_hybrid(
             &provider,
             tx_request,
@@ -957,19 +957,30 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
     )?;
     tracing::Span::current().record("state_update_count", state_updates.len());
 
-    // The unbounded profile's whole bargain: compute may be unbounded, the
-    // on-chain payload may not. Enforce it before signing/estimating anything.
-    if profile.requires_unbounded_shape() {
-        let shape = validate_unbounded_shape(&state_updates).map_err(|violation| {
-            anyhow!(
-                "unbounded-profile payload shape violation for consumer {contract_address}: {violation}"
-            )
-        })?;
+    // The unbounded profile's whole bargain: compute may be unbounded, the payload that lands
+    // on-chain may not. Enforced before signing/estimating anything.
+    //
+    // Priced against the more expensive signature scheme's verification floor, because the payload
+    // is signed before the scheme is fixed — accepting under the cheaper one could admit a payload
+    // the other cannot carry. The bound is analytic (a pure function of the payload) rather than the
+    // revm estimate computed below: this verdict is part of what operators must agree on, and
+    // anything derived from live-fetched state could put two honest operators on opposite sides of
+    // the boundary.
+    if let Some(budget) = profile.payload_gas_budget() {
+        let signature_floor = SignatureType::Bls.turetzky_upper_gas_limit();
+        let cost = validate_unbounded_cost(&state_updates, call_gas_total, signature_floor, budget)
+            .map_err(|violation| {
+                anyhow!(
+                    "unbounded-profile payload rejected for consumer {contract_address}: {violation}"
+                )
+            })?;
         tracing::debug!(
-            stores = shape.stores,
-            calls = shape.calls,
-            logs = shape.logs,
-            "unbounded payload shape OK"
+            stores = cost.stores,
+            calls = cost.calls,
+            logs = cost.logs,
+            applied_gas_upper_bound = cost.applied_gas_upper_bound,
+            budget,
+            "unbounded payload fits the on-chain transaction budget"
         );
     }
 
@@ -1018,21 +1029,23 @@ async fn extract_state_updates_hybrid<P: Provider + DebugApi>(
     consumer: Address,
     encoding: StateEncoding,
     profile: SimProfile,
-) -> Result<(Vec<StateUpdate>, HashSet<Opcode>)> {
+) -> Result<(Vec<StateUpdate>, HashSet<Opcode>, u64)> {
     if encoding.signs_prestate_net()
         && let Some(updates) =
             try_prestate_net(provider, &tx_request, block, consumer, profile).await?
     {
         tracing::Span::current().record("extraction", "prestate_net");
-        return Ok((updates, HashSet::new()));
+        // The net form carries no `Call` ops by construction (eligibility rejects them), so no
+        // external call gas rides with it.
+        return Ok((updates, HashSet::new(), 0));
     }
     tracing::Span::current().record("extraction", "struct_log");
     let trace = get_trace_from_call_with_profile(provider, tx_request, block, profile).await?;
-    let (state_updates, skipped_opcodes, _call_gas_total) = match encoding.struct_log_encoder() {
+    let (state_updates, skipped_opcodes, call_gas_total) = match encoding.struct_log_encoder() {
         StructLogEncoder::Legacy => compute_state_updates(trace)?,
         StructLogEncoder::Canonical => compute_state_updates_canonical(trace, consumer)?,
     };
-    Ok((state_updates, skipped_opcodes))
+    Ok((state_updates, skipped_opcodes, call_gas_total))
 }
 
 /// Build the prestate net form: `Ok(Some(updates))` when the call admits it, `Ok(None)` when the net
@@ -1566,6 +1579,7 @@ mod tests {
     /// via a dedicated step.
     mod anvil_integration {
         use super::*;
+        use gas_analyzer_core::UNBOUNDED_PAYLOAD_GAS_BUDGET;
         use gas_analyzer_rpc::{
             get_call_frame_from_call, get_prestate_diff_from_call, get_trace_from_call,
         };
@@ -1781,7 +1795,7 @@ mod tests {
             to: Address,
             encoding: StateEncoding,
         ) -> (Vec<StateUpdate>, HashSet<Opcode>) {
-            extract_state_updates_hybrid(
+            let (updates, skipped, _) = extract_state_updates_hybrid(
                 provider,
                 call_request(to),
                 BlockId::latest(),
@@ -1790,7 +1804,8 @@ mod tests {
                 SimProfile::Chain,
             )
             .await
-            .expect("extraction failed")
+            .expect("extraction failed");
+            (updates, skipped)
         }
 
         /// Extract under a simulation profile, holding the encoding at `PrestateNet`.
@@ -1799,7 +1814,7 @@ mod tests {
             to: Address,
             profile: SimProfile,
         ) -> (Vec<StateUpdate>, HashSet<Opcode>) {
-            extract_state_updates_hybrid(
+            let (updates, skipped, _) = extract_state_updates_hybrid(
                 provider,
                 call_request(to),
                 BlockId::latest(),
@@ -1808,7 +1823,8 @@ mod tests {
                 profile,
             )
             .await
-            .expect("extraction failed")
+            .expect("extraction failed");
+            (updates, skipped)
         }
 
         /// Run the `PrestateNet` dispatcher and, for comparison, each struct-log encoder directly.
@@ -2139,8 +2155,17 @@ mod tests {
             hex_code("6042600155 620f4240 5b 80 15 6016 57 6001 90 03 6009 56 5b 50 00")
         }
 
+        /// Writes slots 1,000 down to 1, one `SSTORE` each — a diff far too large to apply in a
+        /// single transaction, used to exercise the payload budget.
+        ///
+        /// Layout: PUSH2 1000; loop{ DUP1 ISZERO PUSH1 end JUMPI; DUP1 PUSH1 1 SWAP1 SSTORE;
+        /// PUSH1 1 SWAP1 SUB; PUSH1 3 JUMP }; end: STOP.
+        fn thousand_slot_writer_code() -> Bytes {
+            hex_code("6103e8 5b 80 15 6015 57 80 6001 90 55 6001 90 03 6003 56 5b 00")
+        }
+
         /// Same busy loop, but writing TWO slots — a consumer that is not
-        /// commitment-shaped and must be rejected by the unbounded profile.
+        /// single-slot-commitment-shaped, which the payload budget now permits.
         fn gigagas_two_slot_code() -> Bytes {
             hex_code("620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 6043600255 00")
         }
@@ -2154,9 +2179,8 @@ mod tests {
         /// executed call reports the same. So the payload is neither correct nor empty: it commits an
         /// intermediate state the real execution never ended at.
         ///
-        /// Nothing downstream catches this. It passes the single-slot shape gate (one store is
-        /// exactly what the gate wants), and it is a plain `Ok`, so no caller can distinguish it from
-        /// a genuine result. It is caught only by every operator running a cap-lifted node: a
+        /// Nothing downstream catches this. A one-store payload is comfortably inside the on-chain
+        /// budget, and it is a plain `Ok`, so no caller can distinguish it from a genuine result. It is caught only by every operator running a cap-lifted node: a
         /// minority of clamped nodes are outvoted, but a majority would reach quorum on the partial
         /// write. That is why node provisioning is a consensus requirement here, not a performance
         /// tuning knob.
@@ -2228,7 +2252,7 @@ mod tests {
 
             // Unbounded: identical request; the profile's pinned tx-gas override
             // replaces the request's 3M and the burner completes.
-            let (updates, skipped) = extract_state_updates_hybrid(
+            let (updates, skipped, _) = extract_state_updates_hybrid(
                 &provider,
                 call_request(consumer),
                 BlockId::latest(),
@@ -2244,21 +2268,27 @@ mod tests {
                 &[store_up(1, 0x42), log1_up(0xee, Bytes::new())],
                 "40M gas of compute must reduce to one Store and one Log",
             );
-            validate_unbounded_shape(&updates).expect("burner payload is commitment-shaped");
+            validate_unbounded_cost(
+                &updates,
+                0,
+                SignatureType::Bls.turetzky_upper_gas_limit(),
+                UNBOUNDED_PAYLOAD_GAS_BUDGET,
+            )
+            .expect("a one-store payload is far under the transaction budget");
         }
 
-        /// A two-slot writer extracts fine but must fail the unbounded shape
-        /// gate — the exact check `call_to_encoded_state_updates_with_evmsketch_profiled`
-        /// applies before estimating/encoding.
+        /// A two-slot writer is **accepted**. The gate prices the payload instead of counting its
+        /// writes, so a consumer that is not single-slot-commitment-shaped is fine as long as
+        /// applying its diff fits in one transaction — which two writes comfortably do.
         #[tokio::test(flavor = "multi_thread")]
         #[ignore = "spawns a local anvil; requires foundry on PATH"]
-        async fn test_unbounded_profile_rejects_multi_slot_payload() {
+        async fn unbounded_profile_accepts_a_multi_slot_payload_that_fits() {
             let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
             let provider = anvil.provider();
             let consumer = address!("0x0000000000000000000000000000000000002002");
             set_code(&provider, consumer, gigagas_two_slot_code()).await;
 
-            let (updates, _) = extract_state_updates_hybrid(
+            let (updates, ..) = extract_state_updates_hybrid(
                 &provider,
                 call_request(consumer),
                 BlockId::latest(),
@@ -2267,13 +2297,65 @@ mod tests {
                 SimProfile::Unbounded,
             )
             .await
-            .expect("extraction itself succeeds; only the shape gate rejects");
+            .expect("extraction succeeds");
 
-            let violation = validate_unbounded_shape(&updates)
-                .expect_err("two Store ops must violate the single-slot invariant");
-            assert_eq!(
-                violation,
-                gas_analyzer_core::UnboundedShapeViolation::TooManyStores { count: 2 }
+            let cost = validate_unbounded_cost(
+                &updates,
+                0,
+                SignatureType::Bls.turetzky_upper_gas_limit(),
+                UNBOUNDED_PAYLOAD_GAS_BUDGET,
+            )
+            .expect("two writes are cheap enough to apply on-chain");
+            assert_eq!(cost.stores, 2);
+            assert!(cost.applied_gas_upper_bound < UNBOUNDED_PAYLOAD_GAS_BUDGET);
+        }
+
+        /// The bound that replaced the single-slot rule. A transition writing 1,000 distinct slots
+        /// costs more to apply than EIP-7825 permits a single transaction to spend, so it is
+        /// rejected before anything is encoded or signed.
+        ///
+        /// This is the case the profile actually has to catch: the off-chain compute was affordable
+        /// — that is the point of lifting the limit — but the diff it produced cannot be put on
+        /// chain, and signing it would create a task nobody can settle.
+        #[tokio::test(flavor = "multi_thread")]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
+        async fn unbounded_profile_rejects_a_payload_over_the_transaction_budget() {
+            let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+            let provider = anvil.provider();
+            let consumer = address!("0x0000000000000000000000000000000000002004");
+            set_code(&provider, consumer, thousand_slot_writer_code()).await;
+
+            let (updates, ..) = extract_state_updates_hybrid(
+                &provider,
+                call_request(consumer),
+                BlockId::latest(),
+                consumer,
+                StateEncoding::PrestateNet,
+                SimProfile::Unbounded,
+            )
+            .await
+            .expect("extraction itself succeeds; only the budget gate rejects");
+            assert_eq!(updates.len(), 1_000, "one Store per slot written");
+
+            let violation = validate_unbounded_cost(
+                &updates,
+                0,
+                SignatureType::Bls.turetzky_upper_gas_limit(),
+                UNBOUNDED_PAYLOAD_GAS_BUDGET,
+            )
+            .expect_err("1,000 cold writes cannot fit in one transaction");
+            let gas_analyzer_core::UnboundedCostViolation::PayloadTooExpensive {
+                estimated,
+                budget,
+                stores,
+            } = violation
+            else {
+                panic!("expected PayloadTooExpensive, got {violation:?}");
+            };
+            assert_eq!(stores, 1_000);
+            assert!(
+                estimated > budget,
+                "{estimated} must exceed the {budget} budget"
             );
         }
     }

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -1793,6 +1793,24 @@ mod tests {
             .expect("extraction failed")
         }
 
+        /// Extract under a simulation profile, holding the encoding at `PrestateNet`.
+        async fn extract_under_profile(
+            provider: &RootProvider<Ethereum>,
+            to: Address,
+            profile: SimProfile,
+        ) -> (Vec<StateUpdate>, HashSet<Opcode>) {
+            extract_state_updates_hybrid(
+                provider,
+                call_request(to),
+                BlockId::latest(),
+                to,
+                StateEncoding::PrestateNet,
+                profile,
+            )
+            .await
+            .expect("extraction failed")
+        }
+
         /// Run the `PrestateNet` dispatcher and, for comparison, each struct-log encoder directly.
         ///
         /// `PrestateNet` falls back to the *canonical* encoder for calls with no net form, so that — not
@@ -2115,10 +2133,59 @@ mod tests {
             ))
         }
 
+        /// `SSTORE(1, 0x42)` and then the same busy loop, so the write lands before the gas runs
+        /// out. Jump targets are shifted by the 5 bytes of the leading store.
+        fn write_then_gigagas_code() -> Bytes {
+            hex_code("6042600155 620f4240 5b 80 15 6016 57 6001 90 03 6009 56 5b 50 00")
+        }
+
         /// Same busy loop, but writing TWO slots — a consumer that is not
         /// commitment-shaped and must be rejected by the unbounded profile.
         fn gigagas_two_slot_code() -> Bytes {
             hex_code("620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 6043600255 00")
+        }
+
+        /// The consequence of running `Unbounded` against a node whose execution cap was never
+        /// lifted, pinned so it cannot drift.
+        ///
+        /// The consumer writes one slot and then runs out of gas. Extraction does not fail — it
+        /// succeeds with the writes that happened *before* the gas ran out, because the struct-log
+        /// encoders journal the root frame and never discard it, and a prestate diff of a partly
+        /// executed call reports the same. So the payload is neither correct nor empty: it commits an
+        /// intermediate state the real execution never ended at.
+        ///
+        /// Nothing downstream catches this. It passes the single-slot shape gate (one store is
+        /// exactly what the gate wants), and it is a plain `Ok`, so no caller can distinguish it from
+        /// a genuine result. It is caught only by every operator running a cap-lifted node: a
+        /// minority of clamped nodes are outvoted, but a majority would reach quorum on the partial
+        /// write. That is why node provisioning is a consensus requirement here, not a performance
+        /// tuning knob.
+        #[tokio::test(flavor = "multi_thread")]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
+        async fn chain_profile_oog_after_a_write_yields_a_partial_payload() {
+            let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+            let provider = anvil.provider();
+            let consumer = address!("0x0000000000000000000000000000000000002003");
+            set_code(&provider, consumer, write_then_gigagas_code()).await;
+
+            let (clamped, _) = extract_under_profile(&provider, consumer, SimProfile::Chain).await;
+            assert_updates_eq(
+                &clamped,
+                &[store_up(1, 0x42)],
+                "a clamped node signs the pre-OOG write, not an error and not an empty payload",
+            );
+
+            // The same call on a correctly-provisioned node completes the loop and reaches the same
+            // single store — here the payloads agree, but only because this fixture's write happens
+            // to be its final state. The hazard is that the clamped result is indistinguishable from
+            // a real one regardless.
+            let (lifted, _) =
+                extract_under_profile(&provider, consumer, SimProfile::Unbounded).await;
+            assert_updates_eq(
+                &lifted,
+                &[store_up(1, 0x42)],
+                "the cap-lifted run completes the loop and commits the same slot",
+            );
         }
 
         /// Under `Chain` the burner OOGs (tx gas 3M < 40M needed): the #165 revert
@@ -2143,6 +2210,20 @@ mod tests {
                 ),
                 "OOG under Chain profile must force the struct-log fallback, never an unsound diff; \
                  got {chain_classification:?}"
+            );
+
+            // Pin what the fallback actually *returns*, not just how it classifies. A node whose
+            // execution cap has not been lifted behaves exactly like this: the call OOGs and
+            // extraction succeeds with an empty payload rather than failing. That is not unsound —
+            // an empty diff writes nothing — but it is also not an error the caller can detect, so
+            // a mis-provisioned operator silently signs a payload that disagrees with every
+            // correctly-provisioned one. See `chain_profile_oog_after_a_write_yields_a_partial_payload`
+            // for the sharper case.
+            let (chain_updates, _) =
+                extract_under_profile(&provider, consumer, SimProfile::Chain).await;
+            assert!(
+                chain_updates.is_empty(),
+                "a clamped node yields an empty payload, not an error: {chain_updates:?}"
             );
 
             // Unbounded: identical request; the profile's pinned tx-gas override

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -2133,12 +2133,12 @@ mod tests {
         // These spawn anvil with `--disable-block-gas-limit` (the node-side
         // requirement the profile documents) and prove the mode's two halves:
         // compute beyond any real block extracts fine, and the extracted payload
-        // must still be single-slot shaped.
+        // must still fit in one on-chain transaction.
         // ========================================================================
 
         /// ~40M-gas busy loop (1,000,000 iterations × ~40 gas), then exactly one
-        /// SSTORE(1, 0x42) and one LOG1(topic 0xee) — the single-slot commitment
-        /// shape with compute far beyond a 30M block.
+        /// SSTORE(1, 0x42) and one LOG1(topic 0xee) — a minimal payload with
+        /// compute far beyond a 30M block.
         ///
         /// Layout: PUSH3 1_000_000; loop{ DUP1 ISZERO PUSH1 end JUMPI; PUSH1 1
         /// SWAP1 SUB; PUSH1 4 JUMP }; end: POP; SSTORE; LOG1; STOP.

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -1558,11 +1558,12 @@ mod tests {
     /// End-to-end coverage of the extraction dispatcher and the `rpc` tracer helpers against a
     /// real node, rather than synthetic tracer output.
     ///
-    /// Gated behind the `anvil` feature because these spawn a local `anvil`: `evmsketch` is a
-    /// workspace default member, so without the gate a plain `cargo test` would hard-fail for any
-    /// contributor who has not installed foundry. Mirrors how `gas-analyzer-cli` gates its own
-    /// anvil-backed tests. CI runs them via a dedicated step.
-    #[cfg(feature = "anvil")]
+    /// Every test here is `#[ignore]`d because they spawn a local `anvil`: `evmsketch` is a
+    /// workspace default member, so otherwise a plain `cargo test` would hard-fail for any
+    /// contributor without foundry installed. `#[ignore]` rather than a `#[cfg(feature)]` gate so
+    /// the code still compiles — and therefore still gets linted — in the default build; a feature
+    /// that guards only test code buys nothing but a configuration clippy cannot see. CI runs them
+    /// via a dedicated step.
     mod anvil_integration {
         use super::*;
         use gas_analyzer_rpc::{
@@ -1817,6 +1818,7 @@ mod tests {
         /// of slot 2 disappears, intermediate values collapse, stores are slot-sorted ahead of logs.
         /// Pinning both outputs is what keeps that difference deliberate rather than incidental.
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_net_form_differs_from_struct_log_on_eligible_call() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -1871,6 +1873,7 @@ mod tests {
         /// `index` interleaving working against a real tracer, and the delegatecall
         /// SSTORE must land on the root's storage.
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_delegatecall_log_ordering_matches_between_paths() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -1920,6 +1923,7 @@ mod tests {
         /// back and return exactly what `PrestateNet`'s struct-log encoder — the *canonical* one —
         /// returns (a replayable CALL op + the consumer's own store; the callee's internals excluded).
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_hybrid_falls_back_on_regular_call() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -1962,6 +1966,7 @@ mod tests {
         /// that never happened. This is the test that makes that guard load-bearing rather than
         /// defensive, and it fails if the guard is removed.
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_hybrid_falls_back_on_reverted_call() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -2000,6 +2005,7 @@ mod tests {
         /// node. It is pinned rather than fixed because `Legacy` is frozen: changing it would change the
         /// digest of every deployment still signing it. See gas-analyzer#178.
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_caught_reverted_delegatecall_is_dropped_by_net_form_but_kept_by_legacy() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -2045,6 +2051,7 @@ mod tests {
         /// prestate diff carries the consumer's changed slots, and the call frame
         /// carries logs with `position` populated.
         #[tokio::test]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_prestate_rpc_helpers_return_diff_and_frame() {
             let anvil = LocalAnvil::spawn().await;
             let provider = anvil.provider();
@@ -2119,6 +2126,7 @@ mod tests {
         /// request, gas lifted to the pinned 2^40 override — extracts exactly
         /// [Store(1,0x42), Log1(0xee)] via the prestate fast path.
         #[tokio::test(flavor = "multi_thread")]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_unbounded_profile_extracts_beyond_block_gas_limit() {
             let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
             let provider = anvil.provider();
@@ -2162,6 +2170,7 @@ mod tests {
         /// gate — the exact check `call_to_encoded_state_updates_with_evmsketch_profiled`
         /// applies before estimating/encoding.
         #[tokio::test(flavor = "multi_thread")]
+        #[ignore = "spawns a local anvil; requires foundry on PATH"]
         async fn test_unbounded_profile_rejects_multi_slot_payload() {
             let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
             let provider = anvil.provider();

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -110,14 +110,20 @@ fn gnosis_hardforks() -> EthereumChainHardforks {
 pub mod simple_rpc_db;
 use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 
+// Re-exported so downstream consumers (e.g. the Gas Killer service) can name
+// the profile without a direct gas-analyzer-core dependency.
+pub use gas_analyzer_core::SimProfile;
+
 use gas_analyzer_core::{
     Opcode, PrestateEligibility, StateUpdate, build_state_updates_from_prestate,
     classify_prestate_eligibility, compute_state_updates, compute_state_updates_canonical,
     encode_state_updates_to_abi, estimate_gas_from_operations, extract_operation_counts_from_trace,
+    validate_unbounded_shape,
 };
 use gas_analyzer_estimator::{PrecedingTx, SimEnvOpts};
 use gas_analyzer_rpc::{
-    get_call_frame_from_call, get_prestate_diff_from_call, get_trace_from_call,
+    get_call_frame_from_call_with_profile, get_prestate_diff_from_call_with_profile,
+    get_trace_from_call_with_profile,
 };
 
 // ============================================================================
@@ -845,23 +851,67 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
 
 /// Compute encoded state updates and gas estimate for a transaction call using EvmSketch.
 ///
-/// Simulates the call via `debug_traceCall` at the given block, extracts state updates
-/// under the chosen [`StateEncoding`], encodes them to ABI, and estimates gas. The
-/// executor build step (~50–70 ms, 1× `eth_getBlockByNumber`; plus `eth_chainId` on the
-/// first miss per URL) is skipped on cache hits. The HTTP connection pool for `rpc_url`
-/// is managed by `cache` and shared across calls — pass a persistent
-/// `EvmSketchExecutorCache` for best performance; for one-shot use pass
-/// `&EvmSketchExecutorCache::new(1)`.
+/// Simulates the call via `debug_traceCall` at the given block under the real chain environment,
+/// extracts state updates under the chosen [`StateEncoding`], encodes them to ABI, and estimates gas.
+/// Convenience wrapper over [`call_to_encoded_state_updates_with_evmsketch_profiled`] for the
+/// [`SimProfile::Chain`] case.
 ///
 /// # Returns
 /// `(storage_updates, gas_estimate, is_heuristic, skipped_opcodes)`
-#[tracing::instrument(name = "evmsketch.encode", skip_all, fields(block_number, encoding = ?encoding, extraction = tracing::field::Empty, state_update_count = tracing::field::Empty))]
 pub async fn call_to_encoded_state_updates_with_evmsketch_mode(
     cache: &EvmSketchExecutorCache,
     rpc_url: impl AsRef<str>,
     tx_request: TransactionRequest,
     block_number: u64,
     encoding: StateEncoding,
+) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
+    call_to_encoded_state_updates_with_evmsketch_profiled(
+        cache,
+        rpc_url,
+        tx_request,
+        block_number,
+        encoding,
+        SimProfile::Chain,
+    )
+    .await
+}
+
+/// Compute encoded state updates and gas estimate for a transaction call using EvmSketch, under an
+/// explicit [`StateEncoding`] and [`SimProfile`].
+///
+/// The encoding selects the *signed representation* of the payload; the profile selects the *EVM
+/// environment the tracked function is simulated under*. They are independent axes.
+///
+/// The executor build step (~50–70 ms, 1× `eth_getBlockByNumber`; plus `eth_chainId` on the first
+/// miss per URL) is skipped on cache hits. The HTTP connection pool for `rpc_url` is managed by
+/// `cache` and shared across calls — pass a persistent `EvmSketchExecutorCache` for best performance;
+/// for one-shot use pass `&EvmSketchExecutorCache::new(1)`.
+///
+/// Under [`SimProfile::Unbounded`] the call is simulated with the pinned unbounded gas limits
+/// (`gas_analyzer_core::sim_profile`) so arbitrarily heavy compute can execute off-chain, and the
+/// extracted updates must pass [`validate_unbounded_shape`] (at most one `Store`, no `CREATE`) — a
+/// violation is a hard error, because a payload that writes N slots scales on-chain like a plain
+/// contract and defeats the mode's purpose.
+///
+/// Two things intentionally stay on the real chain's environment:
+/// - the **gas estimate** for applying the payload (`verifyAndUpdate` lands in a real block, so it
+///   must be priced under real limits);
+/// - any `Call` ops inside the payload (they re-execute on-chain at real gas).
+///
+/// The node serving `debug_traceCall` must have its execution cap lifted
+/// (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`); otherwise heavy calls OOG inside the
+/// tracer and extraction fails.
+///
+/// # Returns
+/// `(storage_updates, gas_estimate, is_heuristic, skipped_opcodes)`
+#[tracing::instrument(name = "evmsketch.encode", skip_all, fields(block_number, encoding = ?encoding, profile = ?profile, extraction = tracing::field::Empty, state_update_count = tracing::field::Empty))]
+pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
+    cache: &EvmSketchExecutorCache,
+    rpc_url: impl AsRef<str>,
+    tx_request: TransactionRequest,
+    block_number: u64,
+    encoding: StateEncoding,
+    profile: SimProfile,
 ) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
     let rpc_url = rpc_url.as_ref();
     let provider = cache.get_or_create_trace_provider(rpc_url)?;
@@ -895,10 +945,33 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_mode(
     // concurrently — they are independent, so on a cache miss this hides the executor build behind
     // the trace fetch.
     let ((state_updates, skipped_opcodes), executor) = tokio::try_join!(
-        extract_state_updates_hybrid(&provider, tx_request, block_id, contract_address, encoding),
+        extract_state_updates_hybrid(
+            &provider,
+            tx_request,
+            block_id,
+            contract_address,
+            encoding,
+            profile
+        ),
         cache.get_or_build(rpc_url, block_number),
     )?;
     tracing::Span::current().record("state_update_count", state_updates.len());
+
+    // The unbounded profile's whole bargain: compute may be unbounded, the
+    // on-chain payload may not. Enforce it before signing/estimating anything.
+    if profile.requires_unbounded_shape() {
+        let shape = validate_unbounded_shape(&state_updates).map_err(|violation| {
+            anyhow!(
+                "unbounded-profile payload shape violation for consumer {contract_address}: {violation}"
+            )
+        })?;
+        tracing::debug!(
+            stores = shape.stores,
+            calls = shape.calls,
+            logs = shape.logs,
+            "unbounded payload shape OK"
+        );
+    }
 
     let storage_updates = encode_state_updates_to_abi(&state_updates);
 
@@ -944,15 +1017,17 @@ async fn extract_state_updates_hybrid<P: Provider + DebugApi>(
     block: BlockId,
     consumer: Address,
     encoding: StateEncoding,
+    profile: SimProfile,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>)> {
     if encoding.signs_prestate_net()
-        && let Some(updates) = try_prestate_net(provider, &tx_request, block, consumer).await?
+        && let Some(updates) =
+            try_prestate_net(provider, &tx_request, block, consumer, profile).await?
     {
         tracing::Span::current().record("extraction", "prestate_net");
         return Ok((updates, HashSet::new()));
     }
     tracing::Span::current().record("extraction", "struct_log");
-    let trace = get_trace_from_call(provider, tx_request, block).await?;
+    let trace = get_trace_from_call_with_profile(provider, tx_request, block, profile).await?;
     let (state_updates, skipped_opcodes, _call_gas_total) = match encoding.struct_log_encoder() {
         StructLogEncoder::Legacy => compute_state_updates(trace)?,
         StructLogEncoder::Canonical => compute_state_updates_canonical(trace, consumer)?,
@@ -968,13 +1043,14 @@ async fn try_prestate_net<P: Provider + DebugApi>(
     tx_request: &TransactionRequest,
     block: BlockId,
     consumer: Address,
+    profile: SimProfile,
 ) -> Result<Option<Vec<StateUpdate>>> {
     // Each tracer re-simulates the call, and for the heavy-compute calls this encoding exists to
     // serve that simulation dominates the request — so issue both concurrently rather than paying
     // for two sequential executions.
     let (diff, frame) = tokio::try_join!(
-        get_prestate_diff_from_call(provider, tx_request.clone(), block),
-        get_call_frame_from_call(provider, tx_request.clone(), block),
+        get_prestate_diff_from_call_with_profile(provider, tx_request.clone(), block, profile),
+        get_call_frame_from_call_with_profile(provider, tx_request.clone(), block, profile),
     )?;
     match classify_prestate_eligibility(&frame, &diff, consumer) {
         PrestateEligibility::Eligible => Ok(Some(build_state_updates_from_prestate(
@@ -1489,6 +1565,9 @@ mod tests {
     #[cfg(feature = "anvil")]
     mod anvil_integration {
         use super::*;
+        use gas_analyzer_rpc::{
+            get_call_frame_from_call, get_prestate_diff_from_call, get_trace_from_call,
+        };
 
         // ========================================================================
         // Hybrid prestate/struct-log extraction — anvil integration tests
@@ -1508,6 +1587,13 @@ mod tests {
 
         impl LocalAnvil {
             async fn spawn() -> LocalAnvil {
+                Self::spawn_with(&[]).await
+            }
+
+            /// Spawn with extra anvil flags — e.g. `--disable-block-gas-limit`, which the
+            /// unbounded-profile tests need so `debug_traceCall` honors the lifted tx gas limit
+            /// instead of clamping to the 30M default.
+            async fn spawn_with(extra_args: &[&str]) -> LocalAnvil {
                 // Grab a free port, release it, and hand it to anvil. The tiny
                 // reuse window is acceptable for tests.
                 let port = std::net::TcpListener::bind("127.0.0.1:0")
@@ -1517,6 +1603,7 @@ mod tests {
                     .port();
                 let child = std::process::Command::new("anvil")
                     .args(["--port", &port.to_string(), "--silent"])
+                    .args(extra_args)
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())
                     .spawn()
@@ -1686,7 +1773,8 @@ mod tests {
             classify_prestate_eligibility(&frame, &diff, to)
         }
 
-        /// Extract the same call under an encoding, through the real dispatcher.
+        /// Extract the same call under an encoding, through the real dispatcher, on the real chain
+        /// environment.
         async fn extract_under(
             provider: &RootProvider<Ethereum>,
             to: Address,
@@ -1698,6 +1786,7 @@ mod tests {
                 BlockId::latest(),
                 to,
                 encoding,
+                SimProfile::Chain,
             )
             .await
             .expect("extraction failed")
@@ -1994,6 +2083,107 @@ mod tests {
                 frame.logs[0].topics.as_deref(),
                 Some(&[B256::with_last_byte(0xaa)][..]),
                 "log topic must round-trip"
+            );
+        }
+
+        // ========================================================================
+        // Unbounded profile (SimProfile::Unbounded) — anvil integration tests
+        //
+        // These spawn anvil with `--disable-block-gas-limit` (the node-side
+        // requirement the profile documents) and prove the mode's two halves:
+        // compute beyond any real block extracts fine, and the extracted payload
+        // must still be single-slot shaped.
+        // ========================================================================
+
+        /// ~40M-gas busy loop (1,000,000 iterations × ~40 gas), then exactly one
+        /// SSTORE(1, 0x42) and one LOG1(topic 0xee) — the single-slot commitment
+        /// shape with compute far beyond a 30M block.
+        ///
+        /// Layout: PUSH3 1_000_000; loop{ DUP1 ISZERO PUSH1 end JUMPI; PUSH1 1
+        /// SWAP1 SUB; PUSH1 4 JUMP }; end: POP; SSTORE; LOG1; STOP.
+        fn gigagas_burner_code() -> Bytes {
+            hex_code(&format!(
+                "620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 7f{}60006000a1 00",
+                topic_hex(0xee),
+            ))
+        }
+
+        /// Same busy loop, but writing TWO slots — a consumer that is not
+        /// commitment-shaped and must be rejected by the unbounded profile.
+        fn gigagas_two_slot_code() -> Bytes {
+            hex_code("620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 6043600255 00")
+        }
+
+        /// Under `Chain` the burner OOGs (tx gas 3M < 40M needed): the #165 revert
+        /// classification forces fallback. Under `Unbounded` the same call — same
+        /// request, gas lifted to the pinned 2^40 override — extracts exactly
+        /// [Store(1,0x42), Log1(0xee)] via the prestate fast path.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_unbounded_profile_extracts_beyond_block_gas_limit() {
+            let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+            let provider = anvil.provider();
+            let consumer = address!("0x0000000000000000000000000000000000002001");
+            set_code(&provider, consumer, gigagas_burner_code()).await;
+
+            // Chain profile: the 3M tx gas from call_request stands, the loop
+            // OOGs, and the reverted root frame must classify as Fallback.
+            let chain_classification = classify_call(&provider, consumer).await;
+            assert!(
+                matches!(
+                    &chain_classification,
+                    PrestateEligibility::Fallback(reason) if reason.contains("reverted")
+                ),
+                "OOG under Chain profile must force the struct-log fallback, never an unsound diff; \
+                 got {chain_classification:?}"
+            );
+
+            // Unbounded: identical request; the profile's pinned tx-gas override
+            // replaces the request's 3M and the burner completes.
+            let (updates, skipped) = extract_state_updates_hybrid(
+                &provider,
+                call_request(consumer),
+                BlockId::latest(),
+                consumer,
+                StateEncoding::PrestateNet,
+                SimProfile::Unbounded,
+            )
+            .await
+            .expect("unbounded extraction must succeed on a >30M-gas call");
+            assert!(skipped.is_empty(), "no opcodes should be skipped");
+            assert_updates_eq(
+                &updates,
+                &[store_up(1, 0x42), log1_up(0xee, Bytes::new())],
+                "40M gas of compute must reduce to one Store and one Log",
+            );
+            validate_unbounded_shape(&updates).expect("burner payload is commitment-shaped");
+        }
+
+        /// A two-slot writer extracts fine but must fail the unbounded shape
+        /// gate — the exact check `call_to_encoded_state_updates_with_evmsketch_profiled`
+        /// applies before estimating/encoding.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn test_unbounded_profile_rejects_multi_slot_payload() {
+            let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+            let provider = anvil.provider();
+            let consumer = address!("0x0000000000000000000000000000000000002002");
+            set_code(&provider, consumer, gigagas_two_slot_code()).await;
+
+            let (updates, _) = extract_state_updates_hybrid(
+                &provider,
+                call_request(consumer),
+                BlockId::latest(),
+                consumer,
+                StateEncoding::PrestateNet,
+                SimProfile::Unbounded,
+            )
+            .await
+            .expect("extraction itself succeeds; only the shape gate rejects");
+
+            let violation = validate_unbounded_shape(&updates)
+                .expect_err("two Store ops must violate the single-slot invariant");
+            assert_eq!(
+                violation,
+                gas_analyzer_core::UnboundedShapeViolation::TooManyStores { count: 2 }
             );
         }
     }

--- a/crates/gas-estimator/src/lib.rs
+++ b/crates/gas-estimator/src/lib.rs
@@ -1126,4 +1126,96 @@ mod tests {
         assert_eq!(&bytes[..3], &[0xef, 0x01, 0x00], "delegation prefix");
         assert_eq!(&bytes[3..], delegated.as_slice(), "delegated address");
     }
+
+    // ========================================================================
+    // Unbounded-profile gate: the analytic bound vs. the measured cost
+    // ========================================================================
+
+    /// `gas_analyzer_core::sim_profile::estimate_applied_payload_gas` decides which payloads the
+    /// unbounded profile accepts, and it has to do so *analytically* — a verdict derived from live
+    /// chain state could put two honest operators on opposite sides of the boundary and split
+    /// quorum. That makes it a hand-written reimplementation of a cost model, and a hand-written
+    /// model contains exactly the terms someone remembered to write down. The first version
+    /// omitted the payload's own calldata and the handler's decode/dispatch loop — together ~11%
+    /// per store, which is invisible except within a few percent of the ceiling, exactly where an
+    /// admission gate lives.
+    ///
+    /// This test closes that gap permanently by using the measured path as an oracle for the
+    /// analytic one: revm executing the real payload against the real handler charges intrinsic
+    /// calldata gas and dispatch overhead automatically, so whatever the analytic model forgets
+    /// shows up here as a shortfall. Any future dropped term fails this test rather than shipping
+    /// as an over-admitting gate.
+    ///
+    /// The signature floor is passed as 0, deliberately: at 250,000 it would mask a missing
+    /// per-update term until the payload grew past ~200 updates.
+    #[test]
+    fn analytic_bound_dominates_measured_apply_cost() {
+        use gas_analyzer_core::sim_profile::estimate_applied_payload_gas;
+
+        let target = address!("0x00000000000000000000000000000000000c0de0");
+        let caller = address!("0x000000000000000000000000000000000000beef");
+
+        // CANCUN, not OSAKA: `effective_tx_gas_limit` clamps to EIP-7825's 2^24 under OSAKA, which
+        // would OOG the largest payloads here before they could be measured.
+        let mut sim_env = sim_env_with_spec(SpecId::CANCUN);
+        sim_env.gas_limit = 200_000_000;
+
+        // Slot/value entropy matters: it decides the zero/non-zero split of the encoded payload,
+        // and therefore its transport cost. Cover both ends.
+        let sparse_store = |i: usize| {
+            StateUpdate::Store(IStateUpdateTypes::Store {
+                slot: B256::from(U256::from(i as u64 + 1)),
+                value: B256::from(U256::from(1u64)),
+            })
+        };
+        let dense_store = |i: usize| {
+            StateUpdate::Store(IStateUpdateTypes::Store {
+                slot: B256::from(U256::MAX - U256::from(i as u64)),
+                value: B256::from(U256::MAX - U256::from(i as u64 * 7 + 3)),
+            })
+        };
+        let fat_log = |i: usize| {
+            StateUpdate::Log1(IStateUpdateTypes::Log1 {
+                data: Bytes::from(vec![(i % 251) as u8 + 1; 128]),
+                topic1: B256::from(U256::from(i as u64 + 1)),
+            })
+        };
+
+        /// One payload shape to sweep: a name and a per-index update builder.
+        type Shape<'a> = (&'a str, &'a dyn Fn(usize) -> StateUpdate);
+
+        let mixed = |i: usize| match i % 3 {
+            0 => fat_log(i),
+            1 => dense_store(i),
+            _ => sparse_store(i),
+        };
+        let shapes: [Shape; 4] = [
+            ("sparse stores", &sparse_store),
+            ("dense stores", &dense_store),
+            ("fat logs", &fat_log),
+            ("mixed", &mixed),
+        ];
+
+        for (name, build) in shapes {
+            for n in [1usize, 2, 5, 25, 100, 400, 650] {
+                let updates: Vec<StateUpdate> = (0..n).map(build).collect();
+
+                let mut db = CacheDB::new(EmptyDB::default());
+                fund(&mut db, caller);
+                let measured =
+                    estimate_state_changes_gas(&mut db, target, caller, &updates, &sim_env)
+                        .unwrap_or_else(|e| panic!("{name} n={n}: measurement failed: {e:?}"));
+
+                let analytic = estimate_applied_payload_gas(&updates, 0, 0);
+
+                assert!(
+                    analytic >= measured,
+                    "{name} n={n}: analytic bound {analytic} is BELOW the measured cost \
+                     {measured} (short by {}). The gate would admit a payload that does not fit. \
+                     A term is missing from estimate_applied_payload_gas — see its doc comment.",
+                    measured - analytic
+                );
+            }
+        }
+    }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 
 use alloy::primitives::FixedBytes;
+use alloy::rpc::types::BlockOverrides;
 use alloy::rpc::types::trace::geth::{
     CallConfig, CallFrame, DefaultFrame, DiffMode, GethDebugTracingCallOptions,
     GethDebugTracingOptions, GethDefaultTracingOptions, GethTrace, PreStateConfig, PreStateFrame,
@@ -17,9 +18,39 @@ use alloy_provider::ext::DebugApi;
 use alloy_rpc_types::TransactionTrait;
 use anyhow::{Result, anyhow, bail};
 
+use gas_analyzer_core::SimProfile;
 use gas_analyzer_core::trace::compute_state_updates;
 use gas_analyzer_core::types::{Opcode, StateUpdate};
 use gas_analyzer_estimator::PrecedingTx;
+
+/// Apply a [`SimProfile`]'s environment overrides to a `debug_traceCall`
+/// request: the transaction-level gas limit goes on the request itself, the
+/// block-level gas limit rides in `blockOverrides`.
+///
+/// Under [`SimProfile::Unbounded`] the overrides are pinned protocol
+/// constants (see `gas_analyzer_core::sim_profile`), so they are applied
+/// unconditionally — a caller-supplied `gas` field reflects real-chain limits
+/// that this profile deliberately lifts. Note the node has the last word:
+/// geth/reth clamp `debug_traceCall` gas to `--rpc.gascap` and anvil to its
+/// block gas limit, so unbounded extraction requires a node started with the
+/// cap lifted (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`).
+/// A silently-clamping node makes heavy calls OOG, which surfaces as a revert
+/// classified for fallback rather than an unsound diff.
+fn apply_sim_profile(
+    tx_request: &mut alloy::rpc::types::eth::TransactionRequest,
+    options: &mut GethDebugTracingCallOptions,
+    profile: SimProfile,
+) {
+    if let Some(tx_gas) = profile.tx_gas_limit_override() {
+        tx_request.gas = Some(tx_gas);
+    }
+    if let Some(block_gas) = profile.block_gas_limit_override() {
+        options
+            .block_overrides
+            .get_or_insert_with(BlockOverrides::default)
+            .gas_limit = Some(block_gas);
+    }
+}
 
 /// Get transaction trace from a provider using debug_traceTransaction.
 ///
@@ -64,8 +95,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let tx_request = tx_request.into();
-    let options = GethDebugTracingCallOptions {
+    get_trace_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_trace_from_call`] with an explicit [`SimProfile`] controlling the
+/// simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_trace_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<DefaultFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions {
             config: GethDefaultTracingOptions {
                 enable_memory: Some(true),
@@ -76,6 +123,7 @@ where
         },
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
 
     let GethTrace::Default(trace) = provider
         .debug_trace_call(tx_request, block, options)
@@ -102,7 +150,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let options = GethDebugTracingCallOptions {
+    get_prestate_diff_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_prestate_diff_from_call`] with an explicit [`SimProfile`] controlling
+/// the simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_prestate_diff_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<DiffMode>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::prestate_tracer(PreStateConfig {
             diff_mode: Some(true),
             disable_code: Some(true),
@@ -110,8 +175,9 @@ where
         }),
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
     match provider
-        .debug_trace_call(tx_request.into(), block, options)
+        .debug_trace_call(tx_request, block, options)
         .await
         .map_err(|e| anyhow!("prestate debug_trace_call failed: {}", e))?
     {
@@ -133,15 +199,33 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let options = GethDebugTracingCallOptions {
+    get_call_frame_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_call_frame_from_call`] with an explicit [`SimProfile`] controlling
+/// the simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_call_frame_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<CallFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::call_tracer(CallConfig {
             with_log: Some(true),
             ..Default::default()
         }),
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
     match provider
-        .debug_trace_call(tx_request.into(), block, options)
+        .debug_trace_call(tx_request, block, options)
         .await
         .map_err(|e| anyhow!("callTracer debug_trace_call failed: {}", e))?
     {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -35,7 +35,11 @@ use gas_analyzer_estimator::PrecedingTx;
 /// block gas limit, so unbounded extraction requires a node started with the
 /// cap lifted (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`).
 /// A silently-clamping node makes heavy calls OOG, which surfaces as a revert
-/// classified for fallback rather than an unsound diff.
+/// classified for fallback rather than an unsound diff — but extraction still
+/// returns `Ok`, with an empty payload, or a partial one if writes landed before
+/// the halt. Nothing downstream can distinguish that from a real result, so
+/// cap-lifted nodes are a consensus requirement across the operator set, not a
+/// per-node performance choice. See `docs/UNBOUNDED_MODE.md`.
 fn apply_sim_profile(
     tx_request: &mut alloy::rpc::types::eth::TransactionRequest,
     options: &mut GethDebugTracingCallOptions,

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -1,0 +1,182 @@
+# Unbounded Simulation Mode (`SimProfile::Unbounded`)
+
+**Status:** Implemented (analyzer side) — guest-side mirroring required before slashing ships
+**Related:** [GAS_KILLER_SLASHING_SPEC.md](./GAS_KILLER_SLASHING_SPEC.md), [SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md), solidity-sdk PRs [#51](https://github.com/gas-killer/solidity-sdk/pull/51) (single-slot commitment), [#47](https://github.com/gas-killer/solidity-sdk/pull/47)/[#48](https://github.com/gas-killer/solidity-sdk/pull/48) (multi-call forwarding)
+
+## What it is
+
+Gas Killer's core trade is: **computation happens off-chain, only the net state
+diff lands on-chain.** Until now the analyzer simulated tracked functions under
+the real chain's environment, so a tracked function was still bounded by the
+block gas limit (and post-Osaka, the EIP-7825 2^24 tx cap) — even though nothing
+about the *payload* required that bound.
+
+`SimProfile::Unbounded` removes the bound. The tracked function is simulated
+under pinned, protocol-versioned limits ~24,000× a mainnet block:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `UNBOUNDED_BLOCK_GAS_LIMIT` | `1 << 40` (~1.1 Tgas) | block env gas limit during simulation |
+| `UNBOUNDED_TX_GAS_LIMIT` | `1 << 40` | tx gas limit during simulation (EIP-7825 cap deliberately not applied) |
+
+In exchange, the extracted payload must pass the **single-slot shape gate**
+(`validate_unbounded_shape`):
+
+- at most **one `Store`** — the consumer's commitment slot;
+- **no `CREATE`/`CREATE2`** — initcode replays on-chain at real gas;
+- any number of `Call` / `Log*` ops — but `Call`s re-execute on-chain at real
+  gas prices, so compute inside them is *not* killed. Multi-call forwarding
+  (`applyForwardedUpdates`, one commitment write per sibling contract) rides in
+  this category.
+
+The result: **unbounded Solidity, O(1) on-chain state.** A tracked function may
+iterate a million-entry order book, verify a multi-megabyte witness against a
+commitment, or run a whole matching epoch — what ships to `verifyAndUpdate` is
+one SSTORE, some logs, and bounded calls. The intended consumer shape is the
+single-slot commitment pattern of solidity-sdk PR #51, where the expanded state
+travels as a calldata witness and only its hash lives in storage.
+
+### Calldata
+
+Neither revm nor the EVM protocol caps calldata *size*; calldata is priced in
+gas (EIP-7623 floor). Lifting the gas limits therefore lifts the effective
+calldata bound too — `1 << 40` gas admits ~27 GB of floor-priced calldata.
+Multi-megabyte witnesses simulate fine even though they could never land in a
+real transaction; only the signed payload must fit on-chain.
+
+## How to use it
+
+```rust
+use gas_analyzer_core::SimProfile;
+use gas_analyzer_evmsketch::{
+    EvmSketchExecutorCache, call_to_encoded_state_updates_with_evmsketch_profiled,
+};
+
+let (payload, gas, is_heuristic, skipped) =
+    call_to_encoded_state_updates_with_evmsketch_profiled(
+        &cache, rpc_url, tx_request, block_number, SimProfile::Unbounded,
+    ).await?;
+```
+
+Semantics under `Unbounded`:
+
+1. Both extraction paths (prestate fast path *and* struct-log fallback) run the
+   `debug_traceCall` with `tx.gas = 2^40` and `blockOverrides.gasLimit = 2^40`.
+   The caller's `gas` field is overridden unconditionally — the profile is a
+   pinned protocol environment, not a hint.
+2. The extracted updates are validated against the shape gate; a violation is a
+   **hard error** (a consumer writing N slots scales on-chain like a plain
+   contract and defeats the mode).
+3. The **gas estimate still uses the real chain env** — `verifyAndUpdate` lands
+   in a real block, so applying the payload is priced under real limits.
+
+### Node requirement
+
+The node serving `debug_traceCall` has the last word on simulation gas:
+
+| Node | Requirement |
+|---|---|
+| anvil | `--disable-block-gas-limit` |
+| geth | `--rpc.gascap=0` (or ≥ the profile limit) |
+| reth | `--rpc.gascap` raised accordingly |
+
+A clamping node makes heavy calls OOG inside the tracer. This fails safe: the
+reverted root frame forces the struct-log fallback classification (PR #165), so
+a clamped simulation can produce an error — never an unsound diff.
+
+## Determinism: why the constants are versioned
+
+The environment override is **part of the protocol**, not a local tunable.
+Three parties re-execute the same tracked function and must get bit-identical
+results:
+
+1. **Operators**, when extracting the update payload they BLS/ECDSA-sign.
+2. **This analyzer**, when simulating on a user's behalf.
+3. **The SP1 slashing guest** ([SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md)),
+   when a slasher re-executes the original function inside the zkVM to prove
+   the signed updates wrong.
+
+If the guest ran with the real header's gas limit while operators simulated
+under lifted limits, a heavy-but-honest execution would OOG in the guest,
+produce a different update set, and **falsely slash honest operators**.
+Conversely, ad-hoc per-operator limits would fragment quorum signatures at the
+boundary. Hence:
+
+- The limits are `pub const` in `gas_analyzer_core::sim_profile` — the guest
+  crate must import them from there (the crate is pure/WASM-safe and compiles
+  in a zkVM guest).
+- Any change to the values is a **new profile version** (`UnboundedV2`, …),
+  coordinated across operators and the committed guest ELF — never a silent
+  edit. The guest's public values should commit to the profile version
+  alongside the chain-config hash so a proof under the wrong profile cannot
+  satisfy the verifier.
+
+### Fork support (implemented)
+
+The BreadchainCoop `sp1-contract-call` fork (branch
+`ron/unbounded-env-overrides`, targeting `cancun-v1`) provides the mechanism:
+
+```rust
+use sp1_cc_client_executor::EnvOverrides;
+use gas_analyzer_core::UNBOUNDED_BLOCK_GAS_LIMIT;
+
+let overrides = EnvOverrides::gas_limits(UNBOUNDED_BLOCK_GAS_LIMIT);
+
+// Host: prefetch state under the SAME limits the guest will execute with —
+// a host that OOGs early produces a witness the guest cannot complete on.
+let out = sketch.call_raw_with_overrides(&input, overrides).await?;
+let sketch_input = sketch.finalize().await?;
+
+// Guest: re-execute under the identical env; the overrides are bound into
+// `chainConfigHash` (ChainConfigWithEnvOverrides), so a proof under
+// different limits cannot satisfy the verifier.
+let executor = ClientExecutor::eth(&sketch_input)?;
+executor.execute_and_commit_with_overrides(input, overrides);
+```
+
+Setting `tx_gas_limit` also lifts revm's EIP-7825 cap (2^24, Osaka+) to the
+same value, so execution is identical on both sides of the hardfork boundary.
+Regression tests in the fork pin the two invariants: a ~40M-gas call OOGs at
+exactly the header limit without overrides, and succeeds (burning more than
+any real block) under `gas_limits(1 << 40)`.
+
+> **Latent bug fixed along the way:** upstream sp1-cc assigned the gas limit
+> via `modify_tx_chained` on the context, but `Evm::transact` replaces the tx
+> env with the converted `ContractInput` — whose `TxEnv::default()` carries
+> revm's 2^24 builder default. Every sketch/guest execution was silently
+> capped at **16,777,216 gas** regardless of the header. Any tracked function
+> above ~16.7M gas would have OOG'd in host prefetch and guest re-execution
+> even in "bounded" mode.
+
+Remaining before slashing ships: merge the fork branch into `cancun-v1`, and
+have the slashing guest program (per `SP1_REVM_IMPLEMENTATION_SPEC.md`) pass
+`EnvOverrides::gas_limits(UNBOUNDED_BLOCK_GAS_LIMIT)` — importing the
+constant from `gas-analyzer-core`, never restating it — and commit the profile
+version in its public values.
+
+## What this mode does *not* change
+
+- **Trust model.** The quorum still signs the diff; the proof (when it ships)
+  is a fraud proof, not a validity proof. Unbounded mode widens what operators
+  can compute, not what users must trust.
+- **On-chain application costs.** One commitment SSTORE (~5–22k gas) + BLS/ECDSA
+  verification overhead per `verifyAndUpdate`, regardless of off-chain compute.
+- **`Call` op costs.** Calls in the payload re-execute on-chain at real gas.
+  A forwarded multi-call bundle costs one commitment write per sibling contract
+  plus call overhead — still O(contracts), not O(compute).
+- **The serialization model.** One transition per `transitionIndex` per
+  consumer; a direct on-chain call to a tracked function still invalidates
+  in-flight signed updates. Heavy simulations widen this race window
+  (extraction + signing + proving all take longer than a cheap call) —
+  consumers using unbounded mode should gate direct execution paths.
+
+## Test coverage
+
+- `gas_analyzer_core::sim_profile` unit tests: profile overrides, shape gate
+  (single store / multi store / CREATE rejection / empty payload).
+- `gas-analyzer-evmsketch` anvil-backed integration tests
+  (`test_unbounded_profile_*`): a ~40M-gas busy-loop consumer OOGs under
+  `Chain` (classified `Fallback`, per #165's revert soundness rule) and
+  extracts exactly `[Store, Log1]` under `Unbounded` against a real anvil
+  with `--disable-block-gas-limit`; a two-slot writer extracts but fails the
+  shape gate with `TooManyStores { count: 2 }`.

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -80,9 +80,29 @@ The node serving `debug_traceCall` has the last word on simulation gas:
 | geth | `--rpc.gascap=0` (or ≥ the profile limit) |
 | reth | `--rpc.gascap` raised accordingly |
 
-A clamping node makes heavy calls OOG inside the tracer. This fails safe: the
-reverted root frame forces the struct-log fallback classification (PR #165), so
-a clamped simulation can produce an error — never an unsound diff.
+This is a **consensus requirement, not a performance setting.** Every operator
+must run a cap-lifted node, and a deployment should verify it rather than assume
+it.
+
+A clamping node makes heavy calls OOG inside the tracer. The reverted root frame
+forces the struct-log fallback classification (PR #165), so the diff is never
+*unsound* — but the failure is quieter than that makes it sound, and it is worth
+being precise about what a mis-provisioned operator actually produces:
+
+- Extraction **succeeds**. It returns `Ok`, not an error, so no caller can tell a
+  clamped result from a real one.
+- If the call OOGs before writing anything, the payload is **empty**.
+- If it writes and *then* runs out of gas, the payload contains the writes that
+  landed before the halt — a **partial** state commitment the real execution
+  never ended at. This passes the single-slot shape gate, because one store is
+  exactly what the gate is looking for.
+
+So a clamped node signs a payload that disagrees with every correctly-provisioned
+one. A minority of such nodes is outvoted and simply never reaches quorum. A
+majority would form quorum on the empty or partial payload and commit it. Both
+cases are pinned by `chain_profile_oog_after_a_write_yields_a_partial_payload`
+and `test_unbounded_profile_extracts_beyond_block_gas_limit` in
+`crates/evmsketch`.
 
 ## Determinism: why the constants are versioned
 

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -26,10 +26,20 @@ In exchange, the extracted payload must fit in a single on-chain transaction
 |---|---|---|
 | `UNBOUNDED_PAYLOAD_GAS_BUDGET` | `1 << 24` (16,777,216) | ceiling on the gas needed to apply the payload — EIP-7825's per-transaction cap |
 | `UNBOUNDED_COLD_SSTORE_COST` | `22,100` | price charged per `Store`: cold SLOAD (2,100) + zero→nonzero SSTORE (20,000) |
+| `UNBOUNDED_APPLY_BASE_GAS` | `2,000` | fixed cost of entering `verifyAndUpdate`'s decode/apply loop |
+| `UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE` | `14` | decoding and dispatching one byte of encoded payload |
 
-- Applying the payload — transaction base cost, the signature-verification
-  floor, every `Store`/`Log*`, plus the measured gas of any `Call` ops — must
-  come to no more than the budget.
+Applying the payload must come to no more than the budget, counting all three of:
+
+- **Execution** — every `Store`/`Log*` at its EVM price, plus the measured gas
+  of any `Call` ops, plus the signature-verification floor.
+- **Transport** — the transaction base cost and intrinsic gas for the encoded
+  payload's own bytes (4 per zero byte, 16 per non-zero), or the EIP-7623 floor
+  where that is larger. This scales with payload size, so a gate that omitted it
+  would over-admit every multi-slot payload.
+- **Dispatch** — `UNBOUNDED_APPLY_BASE_GAS` plus
+  `UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE` per byte, for decoding the payload and
+  walking it inside `verifyAndUpdate`.
 - **No `CREATE`/`CREATE2`.** Not a cost question: a net diff cannot reconstruct
   replayable initcode, so contract creation is unrepresentable at any price.
 - Any number of `Call` / `Log*` ops within budget — but `Call`s re-execute
@@ -43,8 +53,9 @@ nothing, and enforces it on the payload, where it is binding.**
 The result: **unbounded Solidity, on-chain state bounded by what a transaction
 can carry.** A tracked function may iterate a million-entry order book, verify a
 multi-megabyte witness, or run a whole matching epoch, and write however many
-slots it likes — roughly 700 cold writes fit under the cap — as long as the diff
-can actually be mined.
+slots it likes — roughly 650 cold writes fit under the cap, a little fewer when
+the slots and values are dense (their bytes cost more to carry) — as long as the
+diff can actually be mined.
 
 The constraint is *priced*, not counted. Consumers whose state is too large for
 one transaction can commit it into fewer slots; in the limit that is the
@@ -66,6 +77,25 @@ payloads that do not fit.
 
 Payloads are priced against the **more expensive** signature scheme's floor,
 since the payload is signed before the scheme is fixed.
+
+That independence has a cost worth being explicit about: the analytic model is a
+hand-written reimplementation of something the measured path gets for free.
+`estimate_state_changes_gas` runs the real encoded payload through revm, so revm
+charges intrinsic calldata gas and the handler's decode loop automatically,
+without anyone having to think about them. A hand-written model contains exactly
+the terms someone remembered to write down — and the first version of this gate
+priced execution only, omitting both transport and dispatch (together ~11% per
+store). That is invisible except within a few percent of the ceiling, which is
+precisely where an admission gate lives.
+
+So the measured path is used as an *oracle* for the analytic one:
+`analytic_bound_dominates_measured_apply_cost` in `gas-analyzer-estimator`
+asserts that `estimate_applied_payload_gas` is never below what revm actually
+charges to apply the same payload, across store-shaped, log-shaped, and mixed
+payloads from 1 to 650 updates, with sparse and dense slot values. It passes the
+signature floor as zero on purpose — at 250,000 a fixed floor would mask a
+missing per-update term until payloads grew past ~200 updates. Any future dropped
+term fails that test instead of shipping as an over-admitting gate.
 
 ### Calldata
 
@@ -235,9 +265,16 @@ are bound into the `chainConfigHash` its proof commits to.
 `gas_analyzer_core::sim_profile` unit tests cover the profile overrides and the
 budget arithmetic: the pinned constants, many stores accepted while they fit, the
 exact boundary (largest fitting payload accepted, one store past it rejected),
-the signature floor and external call gas counting against the budget, the
-tracker slot priced but reported separately, empty and zero-store payloads, and
-`CREATE`/`CREATE2` rejection with the offending index.
+the signature floor and external call gas counting against the budget, transport
+and dispatch priced on top of execution, the tracker slot priced but reported
+separately, empty and zero-store payloads, and `CREATE`/`CREATE2` rejection with
+the offending index.
+
+`gas-analyzer-estimator`'s `analytic_bound_dominates_measured_apply_cost` is the
+one that guards the model rather than its arithmetic — see [Why the bound is
+analytic](#why-the-bound-is-analytic). It measures the real cost with revm and
+asserts the analytic bound never falls below it, so a dropped term fails a test
+instead of loosening the gate.
 
 `gas-analyzer-evmsketch`'s `anvil_integration` module covers the same ground
 against a real anvil started with `--disable-block-gas-limit`. These tests are

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -12,29 +12,59 @@ block gas limit (and post-Osaka, the EIP-7825 2^24 tx cap) — even though nothi
 about the *payload* required that bound.
 
 `SimProfile::Unbounded` removes the bound. The tracked function is simulated
-under pinned, protocol-versioned limits ~24,000× a mainnet block:
+under pinned protocol limits ~24,000× a mainnet block:
 
 | Constant | Value | Meaning |
 |---|---|---|
 | `UNBOUNDED_BLOCK_GAS_LIMIT` | `1 << 40` (~1.1 Tgas) | block env gas limit during simulation |
 | `UNBOUNDED_TX_GAS_LIMIT` | `1 << 40` | tx gas limit during simulation (EIP-7825 cap deliberately not applied) |
 
-In exchange, the extracted payload must pass the **single-slot shape gate**
-(`validate_unbounded_shape`):
+In exchange, the extracted payload must fit in a single on-chain transaction
+(`validate_unbounded_cost`):
 
-- at most **one `Store`** — the consumer's commitment slot;
-- **no `CREATE`/`CREATE2`** — initcode replays on-chain at real gas;
-- any number of `Call` / `Log*` ops — but `Call`s re-execute on-chain at real
-  gas prices, so compute inside them is *not* killed. Multi-call forwarding
-  (`applyForwardedUpdates`, one commitment write per sibling contract) rides in
-  this category.
+| Constant | Value | Meaning |
+|---|---|---|
+| `UNBOUNDED_PAYLOAD_GAS_BUDGET` | `1 << 24` (16,777,216) | ceiling on the gas needed to apply the payload — EIP-7825's per-transaction cap |
+| `UNBOUNDED_COLD_SSTORE_COST` | `22,100` | price charged per `Store`: cold SLOAD (2,100) + zero→nonzero SSTORE (20,000) |
 
-The result: **unbounded Solidity, O(1) on-chain state.** A tracked function may
-iterate a million-entry order book, verify a multi-megabyte witness against a
-commitment, or run a whole matching epoch — what ships to `verifyAndUpdate` is
-one SSTORE, some logs, and bounded calls. The intended consumer shape is the
+- Applying the payload — transaction base cost, the signature-verification
+  floor, every `Store`/`Log*`, plus the measured gas of any `Call` ops — must
+  come to no more than the budget.
+- **No `CREATE`/`CREATE2`.** Not a cost question: a net diff cannot reconstruct
+  replayable initcode, so contract creation is unrepresentable at any price.
+- Any number of `Call` / `Log*` ops within budget — but `Call`s re-execute
+  on-chain at real gas prices, so compute inside them is *not* killed.
+  Multi-call forwarding (`applyForwardedUpdates`) rides in this category.
+
+So the profile **lifts EIP-7825 for the simulation, where the cap protects
+nothing, and enforces it on the payload, where it is binding.**
+
+The result: **unbounded Solidity, on-chain state bounded by what a transaction
+can carry.** A tracked function may iterate a million-entry order book, verify a
+multi-megabyte witness, or run a whole matching epoch, and write however many
+slots it likes — roughly 700 cold writes fit under the cap — as long as the diff
+can actually be mined.
+
+The constraint is *priced*, not counted. Consumers whose state is too large for
+one transaction can commit it into fewer slots; in the limit that is the
 single-slot commitment pattern of solidity-sdk PR #51, where the expanded state
-travels as a calldata witness and only its hash lives in storage.
+travels as a calldata witness and only its hash lives in storage. **That pattern
+is an option for contracts that need it, not a requirement of this mode.**
+
+### Why the bound is analytic
+
+The gate prices the payload with a pure function of the payload
+(`estimate_applied_payload_gas`), not with the revm estimate the same call
+computes for reporting. Accept/reject is part of what operators must agree on: a
+verdict derived from live-fetched state could put two honest operators on
+opposite sides of the boundary and split quorum. For the same reason the gate
+carries its own `UNBOUNDED_COLD_SSTORE_COST` rather than reusing the tuned
+figure in `gas_analyzer_core::heuristic` — that one approximates typical cost for
+user-facing savings numbers, and a gate that under-prices a write would admit
+payloads that do not fit.
+
+Payloads are priced against the **more expensive** signature scheme's floor,
+since the payload is signed before the scheme is fixed.
 
 ### Calldata
 
@@ -64,9 +94,9 @@ Semantics under `Unbounded`:
    `debug_traceCall` with `tx.gas = 2^40` and `blockOverrides.gasLimit = 2^40`.
    The caller's `gas` field is overridden unconditionally — the profile is a
    pinned protocol environment, not a hint.
-2. The extracted updates are validated against the shape gate; a violation is a
-   **hard error** (a consumer writing N slots scales on-chain like a plain
-   contract and defeats the mode).
+2. The extracted updates are priced against the payload budget; a violation is a
+   **hard error** — signing a payload that cannot be mined produces a task
+   nobody can settle.
 3. The **gas estimate still uses the real chain env** — `verifyAndUpdate` lands
    in a real block, so applying the payload is priced under real limits.
 
@@ -94,8 +124,8 @@ being precise about what a mis-provisioned operator actually produces:
 - If the call OOGs before writing anything, the payload is **empty**.
 - If it writes and *then* runs out of gas, the payload contains the writes that
   landed before the halt — a **partial** state commitment the real execution
-  never ended at. This passes the single-slot shape gate, because one store is
-  exactly what the gate is looking for.
+  never ended at. This passes the payload budget — one store is well inside it —
+  so the budget gate cannot catch it either.
 
 So a clamped node signs a payload that disagrees with every correctly-provisioned
 one. A minority of such nodes is outvoted and simply never reaches quorum. A
@@ -192,11 +222,11 @@ version in its public values.
 
 ## Test coverage
 
-- `gas_analyzer_core::sim_profile` unit tests: profile overrides, shape gate
+- `gas_analyzer_core::sim_profile` unit tests: profile overrides, payload budget
   (single store / multi store / CREATE rejection / empty payload).
 - `gas-analyzer-evmsketch` anvil-backed integration tests
   (`test_unbounded_profile_*`): a ~40M-gas busy-loop consumer OOGs under
   `Chain` (classified `Fallback`, per #165's revert soundness rule) and
   extracts exactly `[Store, Log1]` under `Unbounded` against a real anvil
   with `--disable-block-gas-limit`; a two-slot writer extracts but fails the
-  shape gate with `TooManyStores { count: 2 }`.
+  budget with `PayloadTooExpensive` once its diff exceeds one transaction.

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -1,7 +1,7 @@
 # Unbounded Simulation Mode (`SimProfile::Unbounded`)
 
 **Status:** Implemented (analyzer side) — guest-side mirroring required before slashing ships
-**Related:** [GAS_KILLER_SLASHING_SPEC.md](./GAS_KILLER_SLASHING_SPEC.md), [SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md), solidity-sdk PRs [#51](https://github.com/gas-killer/solidity-sdk/pull/51) (single-slot commitment), [#47](https://github.com/gas-killer/solidity-sdk/pull/47)/[#48](https://github.com/gas-killer/solidity-sdk/pull/48) (multi-call forwarding)
+**Related:** [GAS_KILLER_SLASHING_SPEC.md](./GAS_KILLER_SLASHING_SPEC.md), [SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md), solidity-sdk PR [#51](https://github.com/gas-killer/solidity-sdk/pull/51) (single-slot commitment — open, and not a prerequisite for this mode)
 
 ## What it is
 
@@ -33,8 +33,9 @@ In exchange, the extracted payload must fit in a single on-chain transaction
 - **No `CREATE`/`CREATE2`.** Not a cost question: a net diff cannot reconstruct
   replayable initcode, so contract creation is unrepresentable at any price.
 - Any number of `Call` / `Log*` ops within budget — but `Call`s re-execute
-  on-chain at real gas prices, so compute inside them is *not* killed.
-  Multi-call forwarding (`applyForwardedUpdates`) rides in this category.
+  on-chain at real gas prices, so compute inside them is *not* killed. They are
+  priced at the gas the trace measured, so an expensive call spends the same
+  budget a batch of writes would.
 
 So the profile **lifts EIP-7825 for the simulation, where the cap protects
 nothing, and enforces it on the payload, where it is binding.**
@@ -134,7 +135,7 @@ cases are pinned by `chain_profile_oog_after_a_write_yields_a_partial_payload`
 and `test_unbounded_profile_extracts_beyond_block_gas_limit` in
 `crates/evmsketch`.
 
-## Determinism: why the constants are versioned
+## Determinism: why the constants are pinned
 
 The environment override is **part of the protocol**, not a local tunable.
 Three parties re-execute the same tracked function and must get bit-identical
@@ -155,11 +156,14 @@ boundary. Hence:
 - The limits are `pub const` in `gas_analyzer_core::sim_profile` — the guest
   crate must import them from there (the crate is pure/WASM-safe and compiles
   in a zkVM guest).
-- Any change to the values is a **new profile version** (`UnboundedV2`, …),
-  coordinated across operators and the committed guest ELF — never a silent
-  edit. The guest's public values should commit to the profile version
-  alongside the chain-config hash so a proof under the wrong profile cannot
-  satisfy the verifier.
+- Changing a value is a **lockstep fleet rollout** across operators and the
+  committed guest ELF — never a silent edit. What distinguishes one set of
+  limits from another is not the Rust identifier but the values themselves: the
+  guest binds the overrides into `chainConfigHash`
+  (`ChainConfigWithEnvOverrides`), so a proof produced under different limits
+  cannot satisfy a verifier expecting these ones. An operator fleet that has
+  half-rolled a change does not produce quietly-divergent proofs; it produces
+  proofs that fail verification.
 
 ### Fork support (implemented)
 
@@ -198,22 +202,28 @@ any real block) under `gas_limits(1 << 40)`.
 > above ~16.7M gas would have OOG'd in host prefetch and guest re-execution
 > even in "bounded" mode.
 
-Remaining before slashing ships: merge the fork branch into `cancun-v1`, and
-have the slashing guest program (per `SP1_REVM_IMPLEMENTATION_SPEC.md`) pass
-`EnvOverrides::gas_limits(UNBOUNDED_BLOCK_GAS_LIMIT)` — importing the
-constant from `gas-analyzer-core`, never restating it — and commit the profile
-version in its public values.
+Remaining before slashing ships: merge the fork branch into `cancun-v1`
+([sp1-contract-call#12](https://github.com/BreadchainCoop/sp1-contract-call/pull/12),
+still open), and have the slashing guest program (per
+`SP1_REVM_IMPLEMENTATION_SPEC.md`) pass
+`EnvOverrides::gas_limits(UNBOUNDED_BLOCK_GAS_LIMIT)` — importing the constant
+from `gas-analyzer-core`, never restating it — so the limits it executed under
+are bound into the `chainConfigHash` its proof commits to.
 
 ## What this mode does *not* change
 
 - **Trust model.** The quorum still signs the diff; the proof (when it ships)
   is a fraud proof, not a validity proof. Unbounded mode widens what operators
   can compute, not what users must trust.
-- **On-chain application costs.** One commitment SSTORE (~5–22k gas) + BLS/ECDSA
-  verification overhead per `verifyAndUpdate`, regardless of off-chain compute.
-- **`Call` op costs.** Calls in the payload re-execute on-chain at real gas.
-  A forwarded multi-call bundle costs one commitment write per sibling contract
-  plus call overhead — still O(contracts), not O(compute).
+- **On-chain application costs.** Applying a payload costs the transaction base,
+  the BLS/ECDSA verification floor, and the writes and logs the diff actually
+  carries — capped by `UNBOUNDED_PAYLOAD_GAS_BUDGET`, never scaling with
+  off-chain compute. A commitment-shaped consumer stays at one SSTORE; a
+  consumer that writes 300 slots pays for 300, and one that writes 1,000 is
+  rejected rather than made cheap.
+- **`Call` op costs.** Calls in the payload re-execute on-chain at real gas, so
+  compute inside a `Call` is not killed — it is charged against the payload
+  budget at the gas the trace measured.
 - **The serialization model.** One transition per `transitionIndex` per
   consumer; a direct on-chain call to a tracked function still invalidates
   in-flight signed updates. Heavy simulations widen this race window
@@ -222,11 +232,22 @@ version in its public values.
 
 ## Test coverage
 
-- `gas_analyzer_core::sim_profile` unit tests: profile overrides, payload budget
-  (single store / multi store / CREATE rejection / empty payload).
-- `gas-analyzer-evmsketch` anvil-backed integration tests
-  (`test_unbounded_profile_*`): a ~40M-gas busy-loop consumer OOGs under
-  `Chain` (classified `Fallback`, per #165's revert soundness rule) and
-  extracts exactly `[Store, Log1]` under `Unbounded` against a real anvil
-  with `--disable-block-gas-limit`; a two-slot writer extracts but fails the
-  budget with `PayloadTooExpensive` once its diff exceeds one transaction.
+`gas_analyzer_core::sim_profile` unit tests cover the profile overrides and the
+budget arithmetic: the pinned constants, many stores accepted while they fit, the
+exact boundary (largest fitting payload accepted, one store past it rejected),
+the signature floor and external call gas counting against the budget, the
+tracker slot priced but reported separately, empty and zero-store payloads, and
+`CREATE`/`CREATE2` rejection with the offending index.
+
+`gas-analyzer-evmsketch`'s `anvil_integration` module covers the same ground
+against a real anvil started with `--disable-block-gas-limit`. These tests are
+`#[ignore]`d so a plain `cargo test` without foundry on PATH skips rather than
+fails, and CI runs them explicitly (`cargo test -p gas-analyzer-evmsketch
+anvil_integration -- --ignored`):
+
+| test | pins |
+|---|---|
+| `test_unbounded_profile_extracts_beyond_block_gas_limit` | a ~40M-gas busy loop OOGs under `Chain` — classified `Fallback` per #165's revert rule, returning an **empty** payload rather than an error — and reduces to exactly `[Store, Log1]` under `Unbounded` |
+| `chain_profile_oog_after_a_write_yields_a_partial_payload` | a clamped node that writes *then* OOGs returns the pre-OOG write: `Ok`, non-empty, and indistinguishable from a correct result |
+| `unbounded_profile_accepts_a_multi_slot_payload_that_fits` | a two-slot writer is **accepted** — the gate prices the payload rather than counting its writes |
+| `unbounded_profile_rejects_a_payload_over_the_transaction_budget` | a 1,000-slot writer extracts fine and is rejected with `PayloadTooExpensive { stores: 1000 }` |


### PR DESCRIPTION
Stacked on #165, now merged; this branch is synced with `main`.

## What

Gas Killer's core trade is compute-off-chain / state-diff-on-chain — but tracked functions were still simulated under the real chain env, so the block gas limit (and post-Osaka, the EIP-7825 2^24 tx cap) bounded what could be killed. `SimProfile::Unbounded` removes the bound: tracked functions simulate under pinned protocol limits (`2^40` block+tx gas), in exchange for the extracted payload having to fit in a single on-chain transaction. Unbounded Solidity; on-chain state bounded by what a transaction can actually carry.

## How

- **core**: `SimProfile { Chain, Unbounded }`, pinned `UNBOUNDED_*` constants (operators, this analyzer, and the SP1 slashing guest must use bit-identical env or fraud proofs falsely slash honest operators — see `docs/UNBOUNDED_MODE.md`), `validate_unbounded_cost()`.
- **rpc**: `_with_profile` variants of the three `debug_traceCall` helpers; the profile sets `tx.gas` + `blockOverrides.gasLimit` unconditionally (pinned protocol env, not a hint). Node must have its cap lifted (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`); a clamping node falls into the #165 revert-fallback and extraction still returns `Ok` — with an empty or partial payload, which is the sharper failure mode pinned below, not "fails safe".
- **evmsketch**: `call_to_encoded_state_updates_with_evmsketch_profiled()` threads the profile through both extraction paths and enforces the payload budget. Payload gas estimation deliberately stays on the real chain env (`verifyAndUpdate` lands in a real block).
- **guest consistency**: mechanism implemented in BreadchainCoop/sp1-contract-call`ron/unbounded-env-overrides` (companion PR) — overrides are bound into `chainConfigHash` so a proof under different limits can't verify.

## Tests

- core unit tests for the profile + the payload budget gate.
- anvil-backed integration tests (`--disable-block-gas-limit`): a ~40M-gas busy-loop consumer OOGs under `Chain` (forces the #165 revert fallback) and extracts exactly `[Store, Log1]` under `Unbounded`; a two-slot writer is **accepted** (it fits), and a 1,000-slot writer is rejected with `PayloadTooExpensive`.


---

## Updates since review

**Renamed `SimProfile::UnboundedV1` → `Unbounded`** (and `UNBOUNDED_V1_*` → `UNBOUNDED_*`), which is
what the code has carried since the sync with `main`; this description had been left stale. The
suffix carried no wire meaning — nothing serialises the variant name, and the SP1 guest binds the
*values* into `chainConfigHash`, not the identifier — and unsuffixed matches the convention
`StateEncoding::{Legacy, Canonical, PrestateNet}` already sets for equally consensus-critical
variants. The "these are pinned protocol constants, changing them is a lockstep rollout, never a
silent edit" warning now lives explicitly in the `sim_profile` module docs. (See the review thread —
there is a reasonable argument for keeping a version in the type; this is a deliberate call, not an
oversight.)

**Pinned what a clamped node actually produces**, per the review ask. Probing a real node rather than
reasoning about it turned up something sharper than "fails safe":

| scenario (clamping node, `Chain` profile) | result |
|---|---|
| OOG before any write | `Ok([])` — empty |
| write, then OOG | `Ok([Store(1, 0x42)])` — **partial** |

Extraction returns `Ok` in both cases, identically across all three encodings, so nothing downstream
can distinguish a clamped result from a real one — and the partial payload *passes* the gate, because
one store is far inside the payload budget. Both are now pinned by
`chain_profile_oog_after_a_write_yields_a_partial_payload` and an added assertion in
`test_unbounded_profile_extracts_beyond_block_gas_limit`, and `docs/UNBOUNDED_MODE.md` plus the
`apply_sim_profile` docs now state the failure mode plainly instead of "fails safe".



## Payload bound: priced, not counted

The gate no longer requires a single-slot payload. What has to stay bounded is the **gas needed to
apply the diff**, so a transition may write as many slots as fit under
`UNBOUNDED_PAYLOAD_GAS_BUDGET` — EIP-7825's per-transaction cap, `2^24`. Roughly **650 cold writes**
instead of one (a little fewer when slots and values are dense, since their bytes cost more to carry).

That makes the profile symmetric about EIP-7825: it *lifts* the cap for the off-chain simulation,
where it protects nothing, and *enforces* it on the payload, where it is binding. Using the protocol
limit rather than a tuned number also keeps the budget from becoming a knob.

The single-slot commitment pattern (solidity-sdk#51) stays available for contracts whose state is too
large for one transaction — but it is **no longer a requirement of this mode**, which matters given
that #51 is still an open PR.

**The bound is analytic on purpose.** `estimate_applied_payload_gas` is a pure function of the
payload, not the revm estimate the same call computes for reporting: accept/reject is part of what
operators must agree on, and a verdict derived from live-fetched state could put two honest operators
on opposite sides of the boundary and split quorum. For the same reason the gate carries its own
`UNBOUNDED_COLD_SSTORE_COST` (22,100 — cold SLOAD + zero→nonzero SSTORE) rather than reusing
`heuristic`'s tuned warm figure, which is tuned for user-facing savings numbers; a gate that
under-prices a write would admit payloads that do not fit. A compile-time assert pins the gate's
price above the heuristic's so the two cannot drift into each other.

`CREATE`/`CREATE2` remain rejected — not a cost question, a net diff simply cannot reconstruct
replayable initcode.

Tests: budget boundary (largest fitting payload accepted, one store past it rejected), signature
floor and external call gas counted, tracker slot priced but reported separately, plus two
anvil-backed cases — a two-slot writer now **accepted**, and a 1,000-slot writer rejected with
`PayloadTooExpensive`.

### The analytic model needed two more terms than it shipped with

Being independent of live state is right, but it means the model is a hand-written reimplementation
of something the measured path gets for free. `estimate_state_changes_gas` runs the real encoded
payload through revm, so revm charges intrinsic calldata gas and the handler's decode loop
automatically — nobody has to think about them. A hand-written model contains exactly the terms
someone remembered to write down, and this one priced **execution only**:

| at the old 746-store boundary | gas |
|---|---|
| what the gate computed | 16,757,600 |
| payload calldata it did not charge for | +871,528 |
| handler decode/dispatch it did not charge for | +1,273,156 |
| `UNBOUNDED_PAYLOAD_GAS_BUDGET` | 16,777,216 |

So the gate would accept payloads needing ~18.4M gas — a task nobody can settle post-Osaka. Not an
unsound diff and not a false slashing, and invisible except within a few percent of the ceiling,
which is exactly where an admission gate lives. Both terms are now priced off the real encoded
payload (`UNBOUNDED_APPLY_BASE_GAS`, `UNBOUNDED_APPLY_GAS_PER_PAYLOAD_BYTE`, and per-byte intrinsic
gas or the EIP-7623 floor, whichever binds), which is why capacity is ~650 rather than ~746.

The durable part is `analytic_bound_dominates_measured_apply_cost`: it uses the measured path as an
**oracle** for the analytic one, asserting the bound never falls below what revm actually charges
across store-, log-, and mixed-shaped payloads from 1 to 650 updates, sparse and dense. It passes the
signature floor as zero on purpose — a fixed 250,000 would mask a missing per-update term until
payloads passed ~200 updates. It caught the log-dispatch term while this fix was being written, and
it fails if either constant is dropped. Future dropped terms fail a test instead of loosening the
gate.

Caveat recorded in the constants' docs: the oracle is the `StateChangeHandlerGasEstimator` handler —
what this analyzer's own gas figures run through — not the production `verifyAndUpdate`. If that
handler's decode loop is materially more expensive, the per-byte constant needs re-measuring against
it.


