### PR TITLE
feat: pinned code overlays for unbounded simulation (UNBOUNDED_V2)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod constants;
 pub mod encoding;
 pub mod heuristic;
+pub mod overlay;
 pub mod prestate;
 pub mod sim_profile;
 pub mod trace;
@@ -20,6 +21,11 @@ pub use heuristic::{
     BASE_TX_COST, LOG_BASE_COST, LOG_DATA_COST_PER_BYTE, LOG_TOPIC_COST, TraceOperations,
     WARM_SSTORE_COST, estimate_gas_from_operations, estimate_gas_from_state_updates,
     extract_operation_counts_from_trace,
+};
+pub use overlay::{
+    CodeOverlay, ENV_COMMITMENT_DOMAIN_V1, ENV_COMMITMENT_DOMAIN_V2, OVERLAY_CHUNK_PAYLOAD,
+    OVERLAY_DOMAIN_V1, OverlayEnv, OverlayError, env_commitment, overlay_chunk_address,
+    overlay_manifest_hash,
 };
 pub use prestate::{
     PrestateEligibility, build_state_updates_from_prestate, classify_prestate_eligibility,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -31,7 +31,8 @@ pub use prestate::{
     PrestateEligibility, build_state_updates_from_prestate, classify_prestate_eligibility,
 };
 pub use sim_profile::{
-    SimProfile, UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT, UnboundedShape,
+    SimProfile, UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT,
+    UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT, UNBOUNDED_V1_XL_TX_GAS_LIMIT, UnboundedShape,
     UnboundedShapeViolation, validate_unbounded_shape,
 };
 pub use trace::{compute_state_updates, copy_memory, parse_trace_memory};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod constants;
 pub mod encoding;
 pub mod heuristic;
 pub mod prestate;
+pub mod sim_profile;
 pub mod trace;
 pub mod types;
 
@@ -22,6 +23,10 @@ pub use heuristic::{
 };
 pub use prestate::{
     PrestateEligibility, build_state_updates_from_prestate, classify_prestate_eligibility,
+};
+pub use sim_profile::{
+    SimProfile, UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT, UnboundedShape,
+    UnboundedShapeViolation, validate_unbounded_shape,
 };
 pub use trace::{compute_state_updates, copy_memory, parse_trace_memory};
 pub use types::{

--- a/crates/core/src/overlay.rs
+++ b/crates/core/src/overlay.rs
@@ -196,7 +196,10 @@ pub fn env_commitment(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sim_profile::{UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT};
+    use crate::sim_profile::{
+        UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT, UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT,
+        UNBOUNDED_V1_XL_TX_GAS_LIMIT,
+    };
     use alloy_primitives::{address, b256};
 
     /// Cross-ecosystem pin: these vectors are reproduced by
@@ -280,5 +283,14 @@ mod tests {
             Some(&other),
         );
         assert_ne!(v2, v2b, "different bytes must change the commitment");
+
+        // Gas tiers commit differently through the bound limit values alone —
+        // no new domain tag needed for `SimProfile::UnboundedV1Xl`.
+        let v1_xl = env_commitment(
+            UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT,
+            UNBOUNDED_V1_XL_TX_GAS_LIMIT,
+            None,
+        );
+        assert_ne!(v1, v1_xl, "the XL gas tier must change the commitment");
     }
 }

--- a/crates/core/src/overlay.rs
+++ b/crates/core/src/overlay.rs
@@ -1,0 +1,284 @@
+//! Pinned code overlays for unbounded simulation (`UNBOUNDED_V2`).
+//!
+//! An overlay mounts immutable byte blobs — model weights, lookup tables, any
+//! large read-only data — as contract *code* in the simulation environment,
+//! without the blobs ever being deployed on-chain. The consumer contract
+//! commits to a single `manifestHash`; chunk addresses are derived from it, so
+//! no on-chain directory exists either. To EVM execution an overlaid chunk is
+//! indistinguishable from a deployed data contract (`EXTCODESIZE` /
+//! `EXTCODECOPY` behave identically), which is why consumer bytecode is
+//! byte-for-byte the same whether its data is deployed or overlaid.
+//!
+//! # Determinism is protocol-critical (same bargain as `sim_profile`)
+//!
+//! `UnboundedV1` established the rule: the simulation env may deviate from the
+//! real chain only through **versioned protocol constants** shared bit-exactly
+//! by operators, this analyzer, and the SP1 slashing guest. Overlays extend
+//! the pinned env from `{gas limits}` to `{gas limits, address → code}`. The
+//! combined commitment ([`env_commitment`]) must be bound into the guest's
+//! `chainConfigHash` exactly like V1's gas overrides — a fraud proof simulated
+//! under different (or missing) overlay bytes then cannot verify, and honest
+//! operators using the pinned bytes cannot be slashed.
+//!
+//! # Availability, not trust
+//!
+//! Overlay bytes travel out-of-band (HuggingFace, IPFS, mirrors). That is a
+//! *liveness* dependency only: bytes that do not reproduce the manifest hash
+//! are refused at mount time ([`OverlayEnv::from_blobs`] hashes what it is
+//! given), so nobody can forge data against the commitment — at worst the
+//! model is temporarily unservable until someone re-serves the blobs.
+//!
+//! # Consumer-side counterpart
+//!
+//! The address derivation below mirrors `Qwen3Engine.overlayChunkAddress` in
+//! gas-killer/solidity-sdk (`src/examples/onchain-llm/`), which resolves the
+//! same addresses on-chain when its `rootDirectory` is `address(0)`.
+
+use alloy_primitives::{Address, B256, Bytes, keccak256};
+
+/// Payload bytes per overlay chunk: the EIP-170 code-size limit (24,576)
+/// minus the leading `STOP` byte. Chunks are mounted as `0x00 || payload`,
+/// mirroring the SSTORE2-style data contracts the solidity-sdk deploys in
+/// directory mode, so consumer read offsets are identical in both modes.
+pub const OVERLAY_CHUNK_PAYLOAD: usize = 24_575;
+
+/// Domain separator for overlay address derivation (versioned: a change is a
+/// new overlay protocol version).
+pub const OVERLAY_DOMAIN_V1: &[u8] = b"gaskiller.llm.overlay.v1";
+
+/// Domain tag hashed into [`env_commitment`] when overlays are present.
+pub const ENV_COMMITMENT_DOMAIN_V2: &[u8] = b"gaskiller.env.unbounded.v2";
+
+/// Domain tag hashed into [`env_commitment`] for the overlay-free V1 env.
+pub const ENV_COMMITMENT_DOMAIN_V1: &[u8] = b"gaskiller.env.unbounded.v1";
+
+/// One pinned code binding: `code` is mounted at `address` for the duration
+/// of the simulation. `code` includes the leading `0x00` STOP byte.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeOverlay {
+    /// The phantom data-contract address (derived, never deployed).
+    pub address: Address,
+    /// The full runtime code to mount (`0x00 || chunk payload`).
+    pub code: Bytes,
+}
+
+/// A verified overlay set for one model: the manifest hash plus every chunk
+/// binding, in global chunk order (weight chunks first, then tokenizer).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OverlayEnv {
+    /// `keccak256(keccak256(weightsBlob) || keccak256(tokenizerBlob))`.
+    pub manifest: B256,
+    /// Derived-address code bindings for every chunk.
+    pub overlays: Vec<CodeOverlay>,
+}
+
+/// Why an overlay set could not be built or verified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverlayError {
+    /// The blobs hash to a different manifest than the consumer committed to.
+    ManifestMismatch {
+        /// The manifest recomputed from the provided blobs.
+        computed: B256,
+        /// The manifest the consumer (or task) pinned.
+        expected: B256,
+    },
+    /// A blob was empty; an overlay with no bytes is always a mistake.
+    EmptyBlob,
+}
+
+impl core::fmt::Display for OverlayError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OverlayError::ManifestMismatch { computed, expected } => write!(
+                f,
+                "overlay blobs hash to manifest {computed}, but the pinned manifest is {expected}; \
+                 refusing to mount unverified bytes"
+            ),
+            OverlayError::EmptyBlob => write!(f, "overlay blob is empty"),
+        }
+    }
+}
+
+impl std::error::Error for OverlayError {}
+
+/// The manifest hash committed on-chain by overlay-mode consumers:
+/// `keccak256(keccak256(weightsBlob) || keccak256(tokenizerBlob))`.
+pub fn overlay_manifest_hash(weights_blob: &[u8], tokenizer_blob: &[u8]) -> B256 {
+    let mut pre = [0u8; 64];
+    pre[..32].copy_from_slice(keccak256(weights_blob).as_slice());
+    pre[32..].copy_from_slice(keccak256(tokenizer_blob).as_slice());
+    keccak256(pre)
+}
+
+/// The derived phantom address of chunk `index` under `manifest`.
+///
+/// Mirrors `Qwen3Engine.overlayChunkAddress` (solidity-sdk):
+/// `address(uint160(uint256(keccak256(abi.encodePacked(
+///     "gaskiller.llm.overlay.v1", manifestHash, uint64(index))))))`.
+pub fn overlay_chunk_address(manifest: B256, index: u64) -> Address {
+    let mut pre = Vec::with_capacity(OVERLAY_DOMAIN_V1.len() + 32 + 8);
+    pre.extend_from_slice(OVERLAY_DOMAIN_V1);
+    pre.extend_from_slice(manifest.as_slice());
+    pre.extend_from_slice(&index.to_be_bytes());
+    Address::from_slice(&keccak256(pre)[12..])
+}
+
+impl OverlayEnv {
+    /// Chunk two blobs, derive every address, and build the overlay set.
+    ///
+    /// This is the only constructor, so an `OverlayEnv`'s manifest always
+    /// matches its bytes; call [`OverlayEnv::verify`] afterwards to check the
+    /// result against an externally pinned manifest.
+    pub fn from_blobs(weights_blob: &[u8], tokenizer_blob: &[u8]) -> Result<Self, OverlayError> {
+        if weights_blob.is_empty() || tokenizer_blob.is_empty() {
+            return Err(OverlayError::EmptyBlob);
+        }
+        let manifest = overlay_manifest_hash(weights_blob, tokenizer_blob);
+        let mut overlays = Vec::new();
+        for blob in [weights_blob, tokenizer_blob] {
+            for chunk in blob.chunks(OVERLAY_CHUNK_PAYLOAD) {
+                let mut code = Vec::with_capacity(1 + chunk.len());
+                code.push(0x00);
+                code.extend_from_slice(chunk);
+                overlays.push(CodeOverlay {
+                    address: overlay_chunk_address(manifest, overlays.len() as u64),
+                    code: code.into(),
+                });
+            }
+        }
+        Ok(OverlayEnv { manifest, overlays })
+    }
+
+    /// Refuse the env unless its manifest matches the pinned `expected` one.
+    pub fn verify(&self, expected: B256) -> Result<(), OverlayError> {
+        if self.manifest != expected {
+            return Err(OverlayError::ManifestMismatch {
+                computed: self.manifest,
+                expected,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// The versioned commitment over the full simulation environment: gas limits
+/// plus the overlay set (when present). This value — not just the gas
+/// constants — is what the SP1 slashing guest must bind into
+/// `chainConfigHash` for overlay-mode consumers, so that a fraud proof under
+/// different weights cannot verify and honest operators cannot be slashed.
+///
+/// Layout (all fixed-width, keccak over concatenation):
+/// `domain || block_gas_limit_be || tx_gas_limit_be [|| manifest || n_be ||
+///  (address || keccak(code)) * n]` with overlays in chunk order.
+pub fn env_commitment(
+    block_gas_limit: u64,
+    tx_gas_limit: u64,
+    overlay: Option<&OverlayEnv>,
+) -> B256 {
+    let mut pre = Vec::new();
+    match overlay {
+        None => pre.extend_from_slice(ENV_COMMITMENT_DOMAIN_V1),
+        Some(_) => pre.extend_from_slice(ENV_COMMITMENT_DOMAIN_V2),
+    }
+    pre.extend_from_slice(&block_gas_limit.to_be_bytes());
+    pre.extend_from_slice(&tx_gas_limit.to_be_bytes());
+    if let Some(env) = overlay {
+        pre.extend_from_slice(env.manifest.as_slice());
+        pre.extend_from_slice(&(env.overlays.len() as u64).to_be_bytes());
+        for o in &env.overlays {
+            pre.extend_from_slice(o.address.as_slice());
+            pre.extend_from_slice(keccak256(&o.code).as_slice());
+        }
+    }
+    keccak256(pre)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sim_profile::{UNBOUNDED_V1_BLOCK_GAS_LIMIT, UNBOUNDED_V1_TX_GAS_LIMIT};
+    use alloy_primitives::{address, b256};
+
+    /// Cross-ecosystem pin: these vectors are reproduced by
+    /// `Qwen3Engine.overlayChunkAddress` (solidity-sdk, verified via
+    /// `cast call`) and by tools/deploy_anvil.py (pycryptodome keccak).
+    /// manifest = keccak256(keccak256(b"weights") || keccak256(b"tok")).
+    #[test]
+    fn derivation_matches_solidity_vectors() {
+        let manifest = overlay_manifest_hash(b"weights", b"tok");
+        assert_eq!(
+            manifest,
+            b256!("0x78273dda294c05581c6c3ccdb68f94d8df3e54038539debf5e3219534b9ee19f")
+        );
+        assert_eq!(
+            overlay_chunk_address(manifest, 0),
+            address!("0xcf1fbae4bca1b750ab9d36d4d37913e012f8ef18")
+        );
+        assert_eq!(
+            overlay_chunk_address(manifest, 1),
+            address!("0xd0a3009805eecd2b4e342d87d451d8df79ce030b")
+        );
+        assert_eq!(
+            overlay_chunk_address(manifest, 24_298),
+            address!("0x9c8f5689b42824b7699cf0d0f179553e91402922")
+        );
+    }
+
+    #[test]
+    fn from_blobs_chunks_and_prefixes() {
+        // 2.5 chunks of weights, sub-chunk tokenizer
+        let weights = vec![0xAB; OVERLAY_CHUNK_PAYLOAD * 2 + 100];
+        let tok = vec![0xCD; 500];
+        let env = OverlayEnv::from_blobs(&weights, &tok).unwrap();
+        assert_eq!(env.overlays.len(), 4);
+        assert_eq!(env.overlays[0].code.len(), 1 + OVERLAY_CHUNK_PAYLOAD);
+        assert_eq!(env.overlays[0].code[0], 0x00);
+        assert_eq!(env.overlays[2].code.len(), 1 + 100);
+        assert_eq!(env.overlays[3].code.len(), 1 + 500);
+        // addresses follow the global index order
+        for (i, o) in env.overlays.iter().enumerate() {
+            assert_eq!(o.address, overlay_chunk_address(env.manifest, i as u64));
+        }
+        env.verify(env.manifest).unwrap();
+    }
+
+    #[test]
+    fn verify_refuses_wrong_manifest() {
+        let env = OverlayEnv::from_blobs(b"weights", b"tok").unwrap();
+        let err = env.verify(B256::ZERO).unwrap_err();
+        assert!(matches!(err, OverlayError::ManifestMismatch { .. }));
+        assert!(err.to_string().contains("refusing to mount"));
+    }
+
+    #[test]
+    fn empty_blob_is_refused() {
+        assert_eq!(
+            OverlayEnv::from_blobs(b"", b"tok").unwrap_err(),
+            OverlayError::EmptyBlob
+        );
+    }
+
+    #[test]
+    fn env_commitment_is_version_separated_and_content_bound() {
+        let v1 = env_commitment(
+            UNBOUNDED_V1_BLOCK_GAS_LIMIT,
+            UNBOUNDED_V1_TX_GAS_LIMIT,
+            None,
+        );
+        let env = OverlayEnv::from_blobs(b"weights", b"tok").unwrap();
+        let v2 = env_commitment(
+            UNBOUNDED_V1_BLOCK_GAS_LIMIT,
+            UNBOUNDED_V1_TX_GAS_LIMIT,
+            Some(&env),
+        );
+        assert_ne!(v1, v2, "overlay presence must change the commitment");
+
+        let other = OverlayEnv::from_blobs(b"weights2", b"tok").unwrap();
+        let v2b = env_commitment(
+            UNBOUNDED_V1_BLOCK_GAS_LIMIT,
+            UNBOUNDED_V1_TX_GAS_LIMIT,
+            Some(&other),
+        );
+        assert_ne!(v2, v2b, "different bytes must change the commitment");
+    }
+}

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -1,0 +1,311 @@
+//! Simulation environment profiles for Gas Killer execution.
+//!
+//! A [`SimProfile`] pins the EVM environment a tracked function is simulated
+//! under. `Chain` mirrors the real chain (today's behaviour everywhere).
+//! `UnboundedV1` is the Gas Killer *unbounded execution* profile: the tracked
+//! function is simulated with gas limits far above any real block, so
+//! arbitrarily heavy Solidity can be executed off-chain — provided its **net
+//! effect** still fits the Gas Killer on-chain payload shape (at most one
+//! storage write per consumer contract, plus external calls and logs; see
+//! [`validate_unbounded_shape`]). The intended consumer shape is the
+//! single-slot commitment pattern (solidity-sdk PR #51), fanned out across
+//! contracts via multi-call forwarding (solidity-sdk PRs #47/#48).
+//!
+//! # Determinism is protocol-critical
+//!
+//! The profile's limits are **pinned protocol constants**, not tunables.
+//! Every party that re-executes a tracked function must use bit-identical
+//! environment overrides:
+//!
+//! 1. operators, when extracting the state-update payload they sign;
+//! 2. this analyzer, when simulating on a user's behalf;
+//! 3. the SP1 slashing guest (`docs/SP1_REVM_IMPLEMENTATION_SPEC.md`), when a
+//!    slasher re-executes the original function inside the zkVM to prove the
+//!    signed updates wrong.
+//!
+//! If the guest ran with the real header's `gas_limit` while operators
+//! simulated under lifted limits, a heavy-but-honest execution would OOG in
+//! the guest and produce a *different* update set — falsely slashing honest
+//! operators. Conversely, per-operator ad-hoc limits would make quorum
+//! signatures diverge on the boundary. Hence the versioned `V1` constants:
+//! any future change to these values is a new profile version, signalled
+//! out-of-band, never a silent edit.
+//!
+//! Calldata note: neither revm nor the EVM protocol caps calldata *size*;
+//! calldata is bounded only through intrinsic gas (EIP-7623 floor pricing).
+//! Lifting the gas limits therefore lifts the effective calldata bound too —
+//! multi-megabyte witnesses (e.g. the expanded state behind a single-slot
+//! commitment) simulate fine under `UnboundedV1` even though they could never
+//! land in a real transaction. Only the *signed payload* must fit on-chain.
+
+use crate::types::StateUpdate;
+
+/// Block gas limit for the `UnboundedV1` profile: 2^40 ≈ 1.1 Tgas,
+/// ~24,000× a 45M-gas mainnet block.
+///
+/// Chosen instead of `u64::MAX` so intrinsic-gas / refund / floor-cost
+/// arithmetic (all `u64` in revm and in geth's tracer path) cannot overflow,
+/// while still admitting ~27 GB of EIP-7623-priced calldata — far beyond any
+/// realistic witness.
+pub const UNBOUNDED_V1_BLOCK_GAS_LIMIT: u64 = 1 << 40;
+
+/// Transaction gas limit for the `UnboundedV1` profile.
+///
+/// Equal to the block limit: the profile deliberately ignores the EIP-7825
+/// per-transaction cap (2^24) — that cap protects real block building and has
+/// no purpose in an off-chain simulation whose result is applied on-chain as
+/// a Gas Killer payload.
+pub const UNBOUNDED_V1_TX_GAS_LIMIT: u64 = UNBOUNDED_V1_BLOCK_GAS_LIMIT;
+
+/// The EVM environment profile a tracked function is simulated under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SimProfile {
+    /// Mirror the anchored chain's real environment (header gas limit,
+    /// EIP-7825 tx cap where active). This is the historical behaviour and
+    /// the right profile whenever the analyzed call must also be *executable*
+    /// on-chain as-is.
+    #[default]
+    Chain,
+    /// Gas Killer unbounded execution (version 1): simulate with
+    /// [`UNBOUNDED_V1_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_V1_TX_GAS_LIMIT`] and
+    /// enforce the single-slot payload shape on the extracted updates.
+    UnboundedV1,
+}
+
+impl SimProfile {
+    /// Transaction-level gas limit override, if this profile lifts it.
+    pub fn tx_gas_limit_override(&self) -> Option<u64> {
+        match self {
+            SimProfile::Chain => None,
+            SimProfile::UnboundedV1 => Some(UNBOUNDED_V1_TX_GAS_LIMIT),
+        }
+    }
+
+    /// Block-level gas limit override, if this profile lifts it.
+    pub fn block_gas_limit_override(&self) -> Option<u64> {
+        match self {
+            SimProfile::Chain => None,
+            SimProfile::UnboundedV1 => Some(UNBOUNDED_V1_BLOCK_GAS_LIMIT),
+        }
+    }
+
+    /// Whether extracted updates must satisfy [`validate_unbounded_shape`].
+    pub fn requires_unbounded_shape(&self) -> bool {
+        matches!(self, SimProfile::UnboundedV1)
+    }
+}
+
+/// Summary of a payload that passed [`validate_unbounded_shape`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnboundedShape {
+    /// Number of `Store` ops (0 or 1).
+    pub stores: usize,
+    /// Number of `Call` ops. These re-execute **on-chain at real gas prices**
+    /// when the payload is applied — unbounded compute inside a `Call` is NOT
+    /// killed. Forwarded multi-call sub-payloads (`applyForwardedUpdates`)
+    /// ride in this category by design.
+    pub calls: usize,
+    /// Number of `Log0`–`Log4` ops.
+    pub logs: usize,
+}
+
+/// Why a payload is not valid under the unbounded profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnboundedShapeViolation {
+    /// More than one storage write. The unbounded profile exists precisely
+    /// because compute is unbounded while *state* stays O(1): a consumer that
+    /// writes N slots per transition pays N cold SSTOREs on-chain and scales
+    /// like a plain contract. Restructure the consumer around a single-slot
+    /// commitment (solidity-sdk PR #51) instead.
+    TooManyStores {
+        /// Total `Store` ops found.
+        count: usize,
+    },
+    /// `CREATE`/`CREATE2` found. Initcode replays on-chain inside
+    /// `verifyAndUpdate` at real gas prices, so a deployment produced by an
+    /// unbounded simulation may simply not fit in a real block; the struct-log
+    /// path also cannot reconstruct replayable initcode from a net diff.
+    CreateNotAllowed {
+        /// Index of the offending op in the update list.
+        index: usize,
+    },
+}
+
+impl core::fmt::Display for UnboundedShapeViolation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UnboundedShapeViolation::TooManyStores { count } => write!(
+                f,
+                "unbounded profile requires at most one storage write per consumer \
+                 (single-slot commitment pattern), found {count} Store ops; \
+                 restructure the consumer to commit its state into one slot"
+            ),
+            UnboundedShapeViolation::CreateNotAllowed { index } => write!(
+                f,
+                "unbounded profile does not allow CREATE/CREATE2 (update #{index}): \
+                 initcode replays on-chain at real gas prices and may not fit a real block"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UnboundedShapeViolation {}
+
+/// Enforce the `UnboundedV1` payload-shape invariant on extracted updates:
+/// at most one `Store`, no `CREATE`/`CREATE2`; `Call` and `Log*` ops pass.
+///
+/// This is what makes "play fast and loose with the gas limit" sound: the
+/// simulation may burn a terabyte of gas, but the thing that lands on-chain
+/// is provably one SSTORE plus bounded calls/logs. A violation means the
+/// consumer contract is not commitment-shaped — failing loudly here beats
+/// signing a payload whose on-chain application costs O(slots touched).
+pub fn validate_unbounded_shape(
+    updates: &[StateUpdate],
+) -> Result<UnboundedShape, UnboundedShapeViolation> {
+    let mut shape = UnboundedShape {
+        stores: 0,
+        calls: 0,
+        logs: 0,
+    };
+    for (index, update) in updates.iter().enumerate() {
+        match update {
+            StateUpdate::Store(_) => shape.stores += 1,
+            StateUpdate::Call(_) => shape.calls += 1,
+            StateUpdate::Log0(_)
+            | StateUpdate::Log1(_)
+            | StateUpdate::Log2(_)
+            | StateUpdate::Log3(_)
+            | StateUpdate::Log4(_) => shape.logs += 1,
+            StateUpdate::Create(_) | StateUpdate::Create2(_) => {
+                return Err(UnboundedShapeViolation::CreateNotAllowed { index });
+            }
+        }
+    }
+    if shape.stores > 1 {
+        return Err(UnboundedShapeViolation::TooManyStores {
+            count: shape.stores,
+        });
+    }
+    Ok(shape)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::IStateUpdateTypes;
+    use alloy_primitives::{Address, B256, Bytes, U256};
+
+    fn store() -> StateUpdate {
+        StateUpdate::Store(IStateUpdateTypes::Store {
+            slot: B256::ZERO,
+            value: B256::ZERO,
+        })
+    }
+
+    fn call() -> StateUpdate {
+        StateUpdate::Call(IStateUpdateTypes::Call {
+            target: Address::ZERO,
+            value: U256::ZERO,
+            callargs: Bytes::new(),
+        })
+    }
+
+    fn log1() -> StateUpdate {
+        StateUpdate::Log1(IStateUpdateTypes::Log1 {
+            data: Bytes::new(),
+            topic1: B256::ZERO,
+        })
+    }
+
+    fn create() -> StateUpdate {
+        StateUpdate::Create(IStateUpdateTypes::Create {
+            value: U256::ZERO,
+            initcode: Bytes::new(),
+        })
+    }
+
+    #[test]
+    fn chain_profile_overrides_nothing() {
+        assert_eq!(SimProfile::Chain.tx_gas_limit_override(), None);
+        assert_eq!(SimProfile::Chain.block_gas_limit_override(), None);
+        assert!(!SimProfile::Chain.requires_unbounded_shape());
+        assert_eq!(SimProfile::default(), SimProfile::Chain);
+    }
+
+    #[test]
+    fn unbounded_profile_pins_v1_constants() {
+        assert_eq!(
+            SimProfile::UnboundedV1.tx_gas_limit_override(),
+            Some(UNBOUNDED_V1_TX_GAS_LIMIT)
+        );
+        assert_eq!(
+            SimProfile::UnboundedV1.block_gas_limit_override(),
+            Some(UNBOUNDED_V1_BLOCK_GAS_LIMIT)
+        );
+        assert!(SimProfile::UnboundedV1.requires_unbounded_shape());
+        // The constants are protocol-pinned: a change here is a consensus
+        // break with the SP1 slashing guest and must ship as a new version.
+        assert_eq!(UNBOUNDED_V1_BLOCK_GAS_LIMIT, 1 << 40);
+        assert_eq!(UNBOUNDED_V1_TX_GAS_LIMIT, 1 << 40);
+    }
+
+    #[test]
+    fn single_store_with_calls_and_logs_is_valid() {
+        let updates = vec![call(), store(), log1(), call(), log1()];
+        let shape = validate_unbounded_shape(&updates).unwrap();
+        assert_eq!(
+            shape,
+            UnboundedShape {
+                stores: 1,
+                calls: 2,
+                logs: 2
+            }
+        );
+    }
+
+    #[test]
+    fn zero_stores_is_valid() {
+        let shape = validate_unbounded_shape(&[call(), log1()]).unwrap();
+        assert_eq!(shape.stores, 0);
+    }
+
+    #[test]
+    fn empty_payload_is_valid() {
+        let shape = validate_unbounded_shape(&[]).unwrap();
+        assert_eq!(
+            shape,
+            UnboundedShape {
+                stores: 0,
+                calls: 0,
+                logs: 0
+            }
+        );
+    }
+
+    #[test]
+    fn two_stores_is_rejected() {
+        let err = validate_unbounded_shape(&[store(), log1(), store()]).unwrap_err();
+        assert_eq!(err, UnboundedShapeViolation::TooManyStores { count: 2 });
+        assert!(err.to_string().contains("single-slot commitment"));
+    }
+
+    #[test]
+    fn create_is_rejected_at_index() {
+        let err = validate_unbounded_shape(&[store(), create()]).unwrap_err();
+        assert_eq!(err, UnboundedShapeViolation::CreateNotAllowed { index: 1 });
+    }
+
+    #[test]
+    fn create2_is_rejected() {
+        let update = StateUpdate::Create2(IStateUpdateTypes::Create2 {
+            salt: B256::ZERO,
+            value: U256::ZERO,
+            initcode: Bytes::new(),
+        });
+        let err = validate_unbounded_shape(&[update]).unwrap_err();
+        assert!(matches!(
+            err,
+            UnboundedShapeViolation::CreateNotAllowed { index: 0 }
+        ));
+    }
+}

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -39,6 +39,17 @@
 //! land in a real transaction. Only the *signed payload* must fit on-chain.
 
 use crate::types::StateUpdate;
+use alloy_primitives::{B256, b256};
+
+/// The Gas Killer SDK's `StateTracker` transition-counter slot
+/// (`keccak256("gasKiller.stateTracker") - 1`, see solidity-sdk
+/// `StateTracker.sol`). Every `trackState` function bumps it, so every
+/// extracted diff carries a Store to this slot; `verifyAndUpdate`'s own
+/// modifier writes the same value on-chain, making the payload copy
+/// idempotent. It is a fixed protocol slot — one per consumer regardless of
+/// state size — and is therefore exempt from the single-slot shape count.
+pub const STATE_TRACKER_SLOT: B256 =
+    b256!("0xdebfdfd5a50ad117c10898d68b5ccf0893c6b40d4f443f902e2e7646601bdeaf");
 
 /// Block gas limit for the `UnboundedV1` profile: 2^40 ≈ 1.1 Tgas,
 /// ~24,000× a 45M-gas mainnet block.
@@ -98,8 +109,10 @@ impl SimProfile {
 /// Summary of a payload that passed [`validate_unbounded_shape`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnboundedShape {
-    /// Number of `Store` ops (0 or 1).
+    /// Number of `Store` ops other than the [`STATE_TRACKER_SLOT`] (0 or 1).
     pub stores: usize,
+    /// Number of `Store` ops to the fixed [`STATE_TRACKER_SLOT`] (0 or 1).
+    pub tracker_stores: usize,
     /// Number of `Call` ops. These re-execute **on-chain at real gas prices**
     /// when the payload is applied — unbounded compute inside a `Call` is NOT
     /// killed. Forwarded multi-call sub-payloads (`applyForwardedUpdates`)
@@ -152,7 +165,8 @@ impl core::fmt::Display for UnboundedShapeViolation {
 impl std::error::Error for UnboundedShapeViolation {}
 
 /// Enforce the `UnboundedV1` payload-shape invariant on extracted updates:
-/// at most one `Store`, no `CREATE`/`CREATE2`; `Call` and `Log*` ops pass.
+/// at most one `Store` beyond the fixed [`STATE_TRACKER_SLOT`] (which every
+/// `trackState` diff carries), no `CREATE`/`CREATE2`; `Call`/`Log*` ops pass.
 ///
 /// This is what makes "play fast and loose with the gas limit" sound: the
 /// simulation may burn a terabyte of gas, but the thing that lands on-chain
@@ -164,11 +178,15 @@ pub fn validate_unbounded_shape(
 ) -> Result<UnboundedShape, UnboundedShapeViolation> {
     let mut shape = UnboundedShape {
         stores: 0,
+        tracker_stores: 0,
         calls: 0,
         logs: 0,
     };
     for (index, update) in updates.iter().enumerate() {
         match update {
+            StateUpdate::Store(store) if store.slot == STATE_TRACKER_SLOT => {
+                shape.tracker_stores += 1
+            }
             StateUpdate::Store(_) => shape.stores += 1,
             StateUpdate::Call(_) => shape.calls += 1,
             StateUpdate::Log0(_)
@@ -193,7 +211,7 @@ pub fn validate_unbounded_shape(
 mod tests {
     use super::*;
     use crate::types::IStateUpdateTypes;
-    use alloy_primitives::{Address, B256, Bytes, U256};
+    use alloy_primitives::{Address, Bytes, U256};
 
     fn store() -> StateUpdate {
         StateUpdate::Store(IStateUpdateTypes::Store {
@@ -257,6 +275,7 @@ mod tests {
             shape,
             UnboundedShape {
                 stores: 1,
+                tracker_stores: 0,
                 calls: 2,
                 logs: 2
             }
@@ -276,10 +295,23 @@ mod tests {
             shape,
             UnboundedShape {
                 stores: 0,
+                tracker_stores: 0,
                 calls: 0,
                 logs: 0
             }
         );
+    }
+
+    #[test]
+    fn tracker_slot_store_is_exempt() {
+        // The realistic trackState diff: counter bump + one commitment write + log.
+        let tracker = StateUpdate::Store(IStateUpdateTypes::Store {
+            slot: STATE_TRACKER_SLOT,
+            value: B256::with_last_byte(1),
+        });
+        let shape = validate_unbounded_shape(&[tracker, store(), log1()]).unwrap();
+        assert_eq!(shape.stores, 1);
+        assert_eq!(shape.tracker_stores, 1);
     }
 
     #[test]

--- a/crates/core/src/sim_profile.rs
+++ b/crates/core/src/sim_profile.rs
@@ -29,7 +29,10 @@
 //! operators. Conversely, per-operator ad-hoc limits would make quorum
 //! signatures diverge on the boundary. Hence the versioned `V1` constants:
 //! any future change to these values is a new profile version, signalled
-//! out-of-band, never a silent edit.
+//! out-of-band, never a silent edit. `UnboundedV1Xl` is exactly such a
+//! version: the same V1 rules with an 8× gas ceiling (2^43) for multi-Tgas
+//! tasks. (Note: "`UNBOUNDED_V2`" names the orthogonal *code-overlay env*
+//! axis in [`crate::overlay`], not a gas tier.)
 //!
 //! Calldata note: neither revm nor the EVM protocol caps calldata *size*;
 //! calldata is bounded only through intrinsic gas (EIP-7623 floor pricing).
@@ -68,6 +71,23 @@ pub const UNBOUNDED_V1_BLOCK_GAS_LIMIT: u64 = 1 << 40;
 /// a Gas Killer payload.
 pub const UNBOUNDED_V1_TX_GAS_LIMIT: u64 = UNBOUNDED_V1_BLOCK_GAS_LIMIT;
 
+/// Block gas limit for the `UnboundedV1Xl` profile: 2^43 ≈ 8.8 Tgas, 8× the
+/// `UnboundedV1` ceiling.
+///
+/// Raised gas tier of the same V1 profile family, introduced for tasks that
+/// blow through the 2^40 cap — the motivating consumer is Qwen3.5-35B-A3B
+/// on-chain inference at ~3.6 Tgas per call, which 2^43 admits with ~2.4×
+/// headroom. Still chosen instead of `u64::MAX` for the same reason as V1:
+/// intrinsic-gas / refund / floor-cost arithmetic (all `u64` in revm and in
+/// geth's tracer path) must not overflow. The EIP-7623 calldata bound scales
+/// with it (~220 GB of floor-priced calldata — irrelevant in practice).
+pub const UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT: u64 = 1 << 43;
+
+/// Transaction gas limit for the `UnboundedV1Xl` profile. Equal to the block
+/// limit, exactly like [`UNBOUNDED_V1_TX_GAS_LIMIT`] (EIP-7825 deliberately
+/// not applied).
+pub const UNBOUNDED_V1_XL_TX_GAS_LIMIT: u64 = UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT;
+
 /// The EVM environment profile a tracked function is simulated under.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SimProfile {
@@ -81,6 +101,25 @@ pub enum SimProfile {
     /// [`UNBOUNDED_V1_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_V1_TX_GAS_LIMIT`] and
     /// enforce the single-slot payload shape on the extracted updates.
     UnboundedV1,
+    /// Gas Killer unbounded execution, raised gas tier of the V1 family:
+    /// identical to [`SimProfile::UnboundedV1`] in every way — same shape
+    /// gate, same env-commitment scheme — except the pinned gas limits are
+    /// [`UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT`] / [`UNBOUNDED_V1_XL_TX_GAS_LIMIT`]
+    /// (2^43 instead of 2^40), admitting multi-Tgas tasks such as
+    /// Qwen3.5-35B-A3B inference (~3.6 Tgas/call).
+    ///
+    /// It is a distinct versioned profile, not a tunable: operators, the
+    /// analyzer, and the SP1 slashing guest must all select the same tier for
+    /// a given consumer or their update sets diverge on the OOG boundary.
+    /// The overlay env commitment (`overlay::env_commitment`) binds the gas
+    /// limits by value, so V1 and V1-XL environments commit differently with
+    /// no new domain tag.
+    ///
+    /// Naming note: this is a *gas tier* within the V1 profile family.
+    /// "`UNBOUNDED_V2`" is already taken by an orthogonal axis — the pinned
+    /// code-overlay environment (`overlay::ENV_COMMITMENT_DOMAIN_V2`), which
+    /// composes freely with either gas tier.
+    UnboundedV1Xl,
 }
 
 impl SimProfile {
@@ -89,6 +128,7 @@ impl SimProfile {
         match self {
             SimProfile::Chain => None,
             SimProfile::UnboundedV1 => Some(UNBOUNDED_V1_TX_GAS_LIMIT),
+            SimProfile::UnboundedV1Xl => Some(UNBOUNDED_V1_XL_TX_GAS_LIMIT),
         }
     }
 
@@ -97,12 +137,13 @@ impl SimProfile {
         match self {
             SimProfile::Chain => None,
             SimProfile::UnboundedV1 => Some(UNBOUNDED_V1_BLOCK_GAS_LIMIT),
+            SimProfile::UnboundedV1Xl => Some(UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT),
         }
     }
 
     /// Whether extracted updates must satisfy [`validate_unbounded_shape`].
     pub fn requires_unbounded_shape(&self) -> bool {
-        matches!(self, SimProfile::UnboundedV1)
+        matches!(self, SimProfile::UnboundedV1 | SimProfile::UnboundedV1Xl)
     }
 }
 
@@ -265,6 +306,26 @@ mod tests {
         // break with the SP1 slashing guest and must ship as a new version.
         assert_eq!(UNBOUNDED_V1_BLOCK_GAS_LIMIT, 1 << 40);
         assert_eq!(UNBOUNDED_V1_TX_GAS_LIMIT, 1 << 40);
+    }
+
+    #[test]
+    fn unbounded_xl_profile_pins_v1_xl_constants() {
+        assert_eq!(
+            SimProfile::UnboundedV1Xl.tx_gas_limit_override(),
+            Some(UNBOUNDED_V1_XL_TX_GAS_LIMIT)
+        );
+        assert_eq!(
+            SimProfile::UnboundedV1Xl.block_gas_limit_override(),
+            Some(UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT)
+        );
+        // Same shape gate as V1: the tier lifts compute, never payload shape.
+        assert!(SimProfile::UnboundedV1Xl.requires_unbounded_shape());
+        // Protocol-pinned like V1: 2^43 sized for ~3.6-Tgas tasks
+        // (Qwen3.5-35B-A3B inference); a change here is a new version.
+        assert_eq!(UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT, 1 << 43);
+        assert_eq!(UNBOUNDED_V1_XL_TX_GAS_LIMIT, 1 << 43);
+        // The tiers must never silently coincide.
+        assert_ne!(UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT, UNBOUNDED_V1_BLOCK_GAS_LIMIT);
     }
 
     #[test]

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -112,7 +112,7 @@ use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 
 // Re-exported so downstream consumers (e.g. the Gas Killer service) can name
 // the profile without a direct gas-analyzer-core dependency.
-pub use gas_analyzer_core::SimProfile;
+pub use gas_analyzer_core::{OverlayEnv, SimProfile};
 
 use gas_analyzer_core::{
     Opcode, PrestateEligibility, StateUpdate, build_state_updates_from_prestate,
@@ -121,8 +121,8 @@ use gas_analyzer_core::{
 };
 use gas_analyzer_estimator::{PrecedingTx, SimEnvOpts};
 use gas_analyzer_rpc::{
-    get_call_frame_from_call_with_profile, get_prestate_diff_from_call_with_profile,
-    get_trace_from_call_with_profile,
+    get_call_frame_from_call_with_env, get_prestate_diff_from_call_with_env,
+    get_trace_from_call_with_env,
 };
 
 // ============================================================================
@@ -815,6 +815,35 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
     block_number: u64,
     profile: SimProfile,
 ) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
+    call_to_encoded_state_updates_with_evmsketch_env(
+        cache,
+        rpc_url,
+        tx_request,
+        block_number,
+        profile,
+        None,
+    )
+    .await
+}
+
+/// [`call_to_encoded_state_updates_with_evmsketch_profiled`] additionally
+/// mounting a pinned [`OverlayEnv`] (verified against the consumer's
+/// manifest) as code state-overrides for the tracked-function simulation —
+/// the `UNBOUNDED_V2` overlay mode (`docs/UNBOUNDED_OVERLAYS.md`). `None` is
+/// identical to the profiled function.
+///
+/// The overlay participates in simulation only; the payload gas estimate
+/// stays on the real chain env, and overlaid chunks are STOP-prefixed pure
+/// data, so they can never appear as payload `Store`/`Create` targets.
+#[tracing::instrument(name = "evmsketch.encode_env", skip_all, fields(block_number, profile = ?profile, overlay = overlay.is_some(), state_update_count = tracing::field::Empty))]
+pub async fn call_to_encoded_state_updates_with_evmsketch_env(
+    cache: &EvmSketchExecutorCache,
+    rpc_url: impl AsRef<str>,
+    tx_request: TransactionRequest,
+    block_number: u64,
+    profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
+) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
     let rpc_url = rpc_url.as_ref();
     let provider = cache.get_or_create_trace_provider(rpc_url)?;
 
@@ -847,7 +876,14 @@ pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
     // concurrently — they are independent, so on a cache miss this hides the executor build behind
     // the trace fetch.
     let ((state_updates, skipped_opcodes), executor) = tokio::try_join!(
-        extract_state_updates_hybrid(&provider, tx_request, block_id, contract_address, profile),
+        extract_state_updates_hybrid(
+            &provider,
+            tx_request,
+            block_id,
+            contract_address,
+            profile,
+            overlay
+        ),
         cache.get_or_build(rpc_url, block_number),
     )?;
     tracing::Span::current().record("state_update_count", state_updates.len());
@@ -906,13 +942,14 @@ async fn extract_state_updates_hybrid<P: Provider + DebugApi>(
     block: BlockId,
     consumer: Address,
     profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>)> {
     if let Ok(Some(updates)) =
-        try_prestate_fast_path(provider, &tx_request, block, consumer, profile).await
+        try_prestate_fast_path(provider, &tx_request, block, consumer, profile, overlay).await
     {
         return Ok((updates, HashSet::new()));
     }
-    let trace = get_trace_from_call_with_profile(provider, tx_request, block, profile).await?;
+    let trace = get_trace_from_call_with_env(provider, tx_request, block, profile, overlay).await?;
     let (state_updates, skipped_opcodes, _call_gas_total) = compute_state_updates(trace)?;
     Ok((state_updates, skipped_opcodes))
 }
@@ -926,12 +963,13 @@ async fn try_prestate_fast_path<P: Provider + DebugApi>(
     block: BlockId,
     consumer: Address,
     profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
 ) -> Result<Option<Vec<StateUpdate>>> {
     // The two tracer calls are independent — run them concurrently so the fast path costs one
     // round-trip, not two.
     let (diff, frame) = tokio::try_join!(
-        get_prestate_diff_from_call_with_profile(provider, tx_request.clone(), block, profile),
-        get_call_frame_from_call_with_profile(provider, tx_request.clone(), block, profile),
+        get_prestate_diff_from_call_with_env(provider, tx_request.clone(), block, profile, overlay),
+        get_call_frame_from_call_with_env(provider, tx_request.clone(), block, profile, overlay),
     )?;
     match classify_prestate_eligibility(&frame, &diff, consumer) {
         PrestateEligibility::Eligible => Ok(Some(build_state_updates_from_prestate(
@@ -1652,6 +1690,7 @@ mod tests {
             BlockId::latest(),
             to,
             SimProfile::Chain,
+            None,
         )
         .await
         .expect("hybrid extraction failed");
@@ -1972,6 +2011,7 @@ mod tests {
             BlockId::latest(),
             consumer,
             SimProfile::UnboundedV1,
+            None,
         )
         .await
         .expect("unbounded extraction must succeed on a >30M-gas call");
@@ -2000,6 +2040,7 @@ mod tests {
             BlockId::latest(),
             consumer,
             SimProfile::UnboundedV1,
+            None,
         )
         .await
         .expect("extraction itself succeeds; only the shape gate rejects");

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -110,8 +110,12 @@ fn gnosis_hardforks() -> EthereumChainHardforks {
 pub mod simple_rpc_db;
 use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 
+// Re-exported so downstream consumers (e.g. the Gas Killer service) can name
+// the profile without a direct gas-analyzer-core dependency.
+pub use gas_analyzer_core::SimProfile;
+
 use gas_analyzer_core::{
-    Opcode, PrestateEligibility, SimProfile, StateUpdate, build_state_updates_from_prestate,
+    Opcode, PrestateEligibility, StateUpdate, build_state_updates_from_prestate,
     classify_prestate_eligibility, compute_state_updates, encode_state_updates_to_abi,
     estimate_gas_from_operations, extract_operation_counts_from_trace, validate_unbounded_shape,
 };

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -2024,6 +2024,36 @@ mod tests {
         validate_unbounded_shape(&updates).expect("burner payload is commitment-shaped");
     }
 
+    /// The XL gas tier (`SimProfile::UnboundedV1Xl`, pinned 2^43 override)
+    /// must extract the identical payload the V1 tier does on the same call:
+    /// the tier only moves the OOG ceiling, never the extraction semantics or
+    /// the shape gate.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unbounded_xl_profile_extracts_beyond_block_gas_limit() {
+        let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+        let provider = anvil.provider();
+        let consumer = address!("0x0000000000000000000000000000000000002003");
+        set_code(&provider, consumer, gigagas_burner_code()).await;
+
+        let (updates, skipped) = extract_state_updates_hybrid(
+            &provider,
+            call_request(consumer),
+            BlockId::latest(),
+            consumer,
+            SimProfile::UnboundedV1Xl,
+            None,
+        )
+        .await
+        .expect("XL extraction must succeed on a >30M-gas call");
+        assert!(skipped.is_empty(), "no opcodes should be skipped");
+        assert_updates_eq(
+            &updates,
+            &[store_up(1, 0x42), log1_up(0xee, Bytes::new())],
+            "the XL tier must extract the same single-slot payload as V1",
+        );
+        validate_unbounded_shape(&updates).expect("burner payload is commitment-shaped");
+    }
+
     /// A two-slot writer extracts fine but must fail the unbounded shape
     /// gate — the exact check `call_to_encoded_state_updates_with_evmsketch_profiled`
     /// applies before estimating/encoding.

--- a/crates/evmsketch/src/lib.rs
+++ b/crates/evmsketch/src/lib.rs
@@ -111,13 +111,14 @@ pub mod simple_rpc_db;
 use simple_rpc_db::{SimpleRpcDb, prefetch_slots_into_cache};
 
 use gas_analyzer_core::{
-    Opcode, PrestateEligibility, StateUpdate, build_state_updates_from_prestate,
+    Opcode, PrestateEligibility, SimProfile, StateUpdate, build_state_updates_from_prestate,
     classify_prestate_eligibility, compute_state_updates, encode_state_updates_to_abi,
-    estimate_gas_from_operations, extract_operation_counts_from_trace,
+    estimate_gas_from_operations, extract_operation_counts_from_trace, validate_unbounded_shape,
 };
 use gas_analyzer_estimator::{PrecedingTx, SimEnvOpts};
 use gas_analyzer_rpc::{
-    get_call_frame_from_call, get_prestate_diff_from_call, get_trace_from_call,
+    get_call_frame_from_call_with_profile, get_prestate_diff_from_call_with_profile,
+    get_trace_from_call_with_profile,
 };
 
 // ============================================================================
@@ -768,12 +769,47 @@ fn hints_from_state_updates(
 ///
 /// # Returns
 /// `(storage_updates, gas_estimate, is_heuristic, skipped_opcodes)`
-#[tracing::instrument(name = "evmsketch.encode", skip_all, fields(block_number, state_update_count = tracing::field::Empty))]
 pub async fn call_to_encoded_state_updates_with_evmsketch(
     cache: &EvmSketchExecutorCache,
     rpc_url: impl AsRef<str>,
     tx_request: TransactionRequest,
     block_number: u64,
+) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
+    call_to_encoded_state_updates_with_evmsketch_profiled(
+        cache,
+        rpc_url,
+        tx_request,
+        block_number,
+        SimProfile::Chain,
+    )
+    .await
+}
+
+/// [`call_to_encoded_state_updates_with_evmsketch`] with an explicit
+/// [`SimProfile`] for the tracked-function simulation.
+///
+/// Under [`SimProfile::UnboundedV1`] the call is simulated with the pinned
+/// unbounded gas limits (`gas_analyzer_core::sim_profile`) so arbitrarily
+/// heavy compute can execute off-chain, and the extracted updates must pass
+/// [`validate_unbounded_shape`] (at most one `Store`, no `CREATE`) — a
+/// violation is a hard error, because a payload that writes N slots scales
+/// on-chain like a plain contract and defeats the mode's purpose.
+///
+/// Two things intentionally stay on the real chain's environment:
+/// - the **gas estimate** for applying the payload (`verifyAndUpdate` lands in
+///   a real block, so it must be priced under real limits);
+/// - any `Call` ops inside the payload (they re-execute on-chain at real gas).
+///
+/// The node serving `debug_traceCall` must have its execution cap lifted
+/// (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`); otherwise
+/// heavy calls OOG inside the tracer and extraction fails.
+#[tracing::instrument(name = "evmsketch.encode", skip_all, fields(block_number, profile = ?profile, state_update_count = tracing::field::Empty))]
+pub async fn call_to_encoded_state_updates_with_evmsketch_profiled(
+    cache: &EvmSketchExecutorCache,
+    rpc_url: impl AsRef<str>,
+    tx_request: TransactionRequest,
+    block_number: u64,
+    profile: SimProfile,
 ) -> Result<(Bytes, u64, bool, HashSet<Opcode>)> {
     let rpc_url = rpc_url.as_ref();
     let provider = cache.get_or_create_trace_provider(rpc_url)?;
@@ -807,10 +843,26 @@ pub async fn call_to_encoded_state_updates_with_evmsketch(
     // concurrently — they are independent, so on a cache miss this hides the executor build behind
     // the trace fetch.
     let ((state_updates, skipped_opcodes), executor) = tokio::try_join!(
-        extract_state_updates_hybrid(&provider, tx_request, block_id, contract_address),
+        extract_state_updates_hybrid(&provider, tx_request, block_id, contract_address, profile),
         cache.get_or_build(rpc_url, block_number),
     )?;
     tracing::Span::current().record("state_update_count", state_updates.len());
+
+    // The unbounded profile's whole bargain: compute may be unbounded, the
+    // on-chain payload may not. Enforce it before signing/estimating anything.
+    if profile.requires_unbounded_shape() {
+        let shape = validate_unbounded_shape(&state_updates).map_err(|violation| {
+            anyhow!(
+                "unbounded-profile payload shape violation for consumer {contract_address}: {violation}"
+            )
+        })?;
+        tracing::debug!(
+            stores = shape.stores,
+            calls = shape.calls,
+            logs = shape.logs,
+            "unbounded payload shape OK"
+        );
+    }
 
     let storage_updates = encode_state_updates_to_abi(&state_updates);
 
@@ -849,12 +901,14 @@ async fn extract_state_updates_hybrid<P: Provider + DebugApi>(
     tx_request: TransactionRequest,
     block: BlockId,
     consumer: Address,
+    profile: SimProfile,
 ) -> Result<(Vec<StateUpdate>, HashSet<Opcode>)> {
-    if let Ok(Some(updates)) = try_prestate_fast_path(provider, &tx_request, block, consumer).await
+    if let Ok(Some(updates)) =
+        try_prestate_fast_path(provider, &tx_request, block, consumer, profile).await
     {
         return Ok((updates, HashSet::new()));
     }
-    let trace = get_trace_from_call(provider, tx_request, block).await?;
+    let trace = get_trace_from_call_with_profile(provider, tx_request, block, profile).await?;
     let (state_updates, skipped_opcodes, _call_gas_total) = compute_state_updates(trace)?;
     Ok((state_updates, skipped_opcodes))
 }
@@ -867,12 +921,13 @@ async fn try_prestate_fast_path<P: Provider + DebugApi>(
     tx_request: &TransactionRequest,
     block: BlockId,
     consumer: Address,
+    profile: SimProfile,
 ) -> Result<Option<Vec<StateUpdate>>> {
     // The two tracer calls are independent — run them concurrently so the fast path costs one
     // round-trip, not two.
     let (diff, frame) = tokio::try_join!(
-        get_prestate_diff_from_call(provider, tx_request.clone(), block),
-        get_call_frame_from_call(provider, tx_request.clone(), block),
+        get_prestate_diff_from_call_with_profile(provider, tx_request.clone(), block, profile),
+        get_call_frame_from_call_with_profile(provider, tx_request.clone(), block, profile),
     )?;
     match classify_prestate_eligibility(&frame, &diff, consumer) {
         PrestateEligibility::Eligible => Ok(Some(build_state_updates_from_prestate(
@@ -895,6 +950,9 @@ mod tests {
     use alloy::primitives::{address, bytes};
     use alloy::providers::ProviderBuilder;
     use gas_analyzer_core::types::IStateUpdateTypes;
+    use gas_analyzer_rpc::{
+        get_call_frame_from_call, get_prestate_diff_from_call, get_trace_from_call,
+    };
 
     /// `with_chain_id` must store the supplied value so `build` can bypass the
     /// `eth_chainId` probe.
@@ -1395,6 +1453,13 @@ mod tests {
 
     impl LocalAnvil {
         async fn spawn() -> LocalAnvil {
+            Self::spawn_with(&[]).await
+        }
+
+        /// Spawn with extra anvil flags — e.g. `--disable-block-gas-limit`,
+        /// which the unbounded-profile tests need so `debug_traceCall` honors
+        /// the lifted tx gas limit instead of clamping to the 30M default.
+        async fn spawn_with(extra_args: &[&str]) -> LocalAnvil {
             // Grab a free port, release it, and hand it to anvil. The tiny
             // reuse window is acceptable for tests.
             let port = std::net::TcpListener::bind("127.0.0.1:0")
@@ -1404,6 +1469,7 @@ mod tests {
                 .port();
             let child = std::process::Command::new("anvil")
                 .args(["--port", &port.to_string(), "--silent"])
+                .args(extra_args)
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .spawn()
@@ -1576,10 +1642,15 @@ mod tests {
         provider: &RootProvider<Ethereum>,
         to: Address,
     ) -> ((Vec<StateUpdate>, HashSet<Opcode>), Vec<StateUpdate>) {
-        let hybrid =
-            extract_state_updates_hybrid(provider, call_request(to), BlockId::latest(), to)
-                .await
-                .expect("hybrid extraction failed");
+        let hybrid = extract_state_updates_hybrid(
+            provider,
+            call_request(to),
+            BlockId::latest(),
+            to,
+            SimProfile::Chain,
+        )
+        .await
+        .expect("hybrid extraction failed");
         let trace = get_trace_from_call(provider, call_request(to), BlockId::latest())
             .await
             .expect("struct-log debug_traceCall failed");
@@ -1835,6 +1906,105 @@ mod tests {
             frame.logs[0].topics.as_deref(),
             Some(&[B256::with_last_byte(0xaa)][..]),
             "log topic must round-trip"
+        );
+    }
+
+    // ========================================================================
+    // Unbounded profile (SimProfile::UnboundedV1) — anvil integration tests
+    //
+    // These spawn anvil with `--disable-block-gas-limit` (the node-side
+    // requirement the profile documents) and prove the mode's two halves:
+    // compute beyond any real block extracts fine, and the extracted payload
+    // must still be single-slot shaped.
+    // ========================================================================
+
+    /// ~40M-gas busy loop (1,000,000 iterations × ~40 gas), then exactly one
+    /// SSTORE(1, 0x42) and one LOG1(topic 0xee) — the single-slot commitment
+    /// shape with compute far beyond a 30M block.
+    ///
+    /// Layout: PUSH3 1_000_000; loop{ DUP1 ISZERO PUSH1 end JUMPI; PUSH1 1
+    /// SWAP1 SUB; PUSH1 4 JUMP }; end: POP; SSTORE; LOG1; STOP.
+    fn gigagas_burner_code() -> Bytes {
+        hex_code(&format!(
+            "620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 7f{}60006000a1 00",
+            topic_hex(0xee),
+        ))
+    }
+
+    /// Same busy loop, but writing TWO slots — a consumer that is not
+    /// commitment-shaped and must be rejected by the unbounded profile.
+    fn gigagas_two_slot_code() -> Bytes {
+        hex_code("620f4240 5b 80 15 6011 57 6001 90 03 6004 56 5b 50 6042600155 6043600255 00")
+    }
+
+    /// Under `Chain` the burner OOGs (tx gas 3M < 40M needed): the #165 revert
+    /// classification forces fallback. Under `UnboundedV1` the same call — same
+    /// request, gas lifted to the pinned 2^40 override — extracts exactly
+    /// [Store(1,0x42), Log1(0xee)] via the prestate fast path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unbounded_profile_extracts_beyond_block_gas_limit() {
+        let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+        let provider = anvil.provider();
+        let consumer = address!("0x0000000000000000000000000000000000002001");
+        set_code(&provider, consumer, gigagas_burner_code()).await;
+
+        // Chain profile: the 3M tx gas from call_request stands, the loop
+        // OOGs, and the reverted root frame must classify as Fallback.
+        let chain_classification = classify_call(&provider, consumer).await;
+        assert!(
+            matches!(
+                &chain_classification,
+                PrestateEligibility::Fallback(reason) if reason.contains("reverted/failed")
+            ),
+            "OOG under Chain profile must force the struct-log fallback, never an unsound diff; \
+             got {chain_classification:?}"
+        );
+
+        // UnboundedV1: identical request; the profile's pinned tx-gas override
+        // replaces the request's 3M and the burner completes.
+        let (updates, skipped) = extract_state_updates_hybrid(
+            &provider,
+            call_request(consumer),
+            BlockId::latest(),
+            consumer,
+            SimProfile::UnboundedV1,
+        )
+        .await
+        .expect("unbounded extraction must succeed on a >30M-gas call");
+        assert!(skipped.is_empty(), "no opcodes should be skipped");
+        assert_updates_eq(
+            &updates,
+            &[store_up(1, 0x42), log1_up(0xee, Bytes::new())],
+            "40M gas of compute must reduce to one Store and one Log",
+        );
+        validate_unbounded_shape(&updates).expect("burner payload is commitment-shaped");
+    }
+
+    /// A two-slot writer extracts fine but must fail the unbounded shape
+    /// gate — the exact check `call_to_encoded_state_updates_with_evmsketch_profiled`
+    /// applies before estimating/encoding.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unbounded_profile_rejects_multi_slot_payload() {
+        let anvil = LocalAnvil::spawn_with(&["--disable-block-gas-limit"]).await;
+        let provider = anvil.provider();
+        let consumer = address!("0x0000000000000000000000000000000000002002");
+        set_code(&provider, consumer, gigagas_two_slot_code()).await;
+
+        let (updates, _) = extract_state_updates_hybrid(
+            &provider,
+            call_request(consumer),
+            BlockId::latest(),
+            consumer,
+            SimProfile::UnboundedV1,
+        )
+        .await
+        .expect("extraction itself succeeds; only the shape gate rejects");
+
+        let violation = validate_unbounded_shape(&updates)
+            .expect_err("two Store ops must violate the single-slot invariant");
+        assert_eq!(
+            violation,
+            gas_analyzer_core::UnboundedShapeViolation::TooManyStores { count: 2 }
         );
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 
 use alloy::primitives::FixedBytes;
+use alloy::rpc::types::BlockOverrides;
 use alloy::rpc::types::trace::geth::{
     CallConfig, CallFrame, DefaultFrame, DiffMode, GethDebugTracingCallOptions,
     GethDebugTracingOptions, GethDefaultTracingOptions, GethTrace, PreStateConfig, PreStateFrame,
@@ -17,9 +18,39 @@ use alloy_provider::ext::DebugApi;
 use alloy_rpc_types::TransactionTrait;
 use anyhow::{Result, anyhow, bail};
 
+use gas_analyzer_core::SimProfile;
 use gas_analyzer_core::trace::compute_state_updates;
 use gas_analyzer_core::types::{Opcode, StateUpdate};
 use gas_analyzer_estimator::PrecedingTx;
+
+/// Apply a [`SimProfile`]'s environment overrides to a `debug_traceCall`
+/// request: the transaction-level gas limit goes on the request itself, the
+/// block-level gas limit rides in `blockOverrides`.
+///
+/// Under [`SimProfile::UnboundedV1`] the overrides are pinned protocol
+/// constants (see `gas_analyzer_core::sim_profile`), so they are applied
+/// unconditionally — a caller-supplied `gas` field reflects real-chain limits
+/// that this profile deliberately lifts. Note the node has the last word:
+/// geth/reth clamp `debug_traceCall` gas to `--rpc.gascap` and anvil to its
+/// block gas limit, so unbounded extraction requires a node started with the
+/// cap lifted (`anvil --disable-block-gas-limit`, `geth --rpc.gascap=0`).
+/// A silently-clamping node makes heavy calls OOG, which surfaces as a revert
+/// classified for fallback rather than an unsound diff.
+fn apply_sim_profile(
+    tx_request: &mut alloy::rpc::types::eth::TransactionRequest,
+    options: &mut GethDebugTracingCallOptions,
+    profile: SimProfile,
+) {
+    if let Some(tx_gas) = profile.tx_gas_limit_override() {
+        tx_request.gas = Some(tx_gas);
+    }
+    if let Some(block_gas) = profile.block_gas_limit_override() {
+        options
+            .block_overrides
+            .get_or_insert_with(BlockOverrides::default)
+            .gas_limit = Some(block_gas);
+    }
+}
 
 /// Get transaction trace from a provider using debug_traceTransaction.
 ///
@@ -64,8 +95,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let tx_request = tx_request.into();
-    let options = GethDebugTracingCallOptions {
+    get_trace_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_trace_from_call`] with an explicit [`SimProfile`] controlling the
+/// simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_trace_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<DefaultFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions {
             config: GethDefaultTracingOptions {
                 enable_memory: Some(true),
@@ -76,6 +123,7 @@ where
         },
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
 
     let GethTrace::Default(trace) = provider
         .debug_trace_call(tx_request, block, options)
@@ -102,7 +150,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let options = GethDebugTracingCallOptions {
+    get_prestate_diff_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_prestate_diff_from_call`] with an explicit [`SimProfile`] controlling
+/// the simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_prestate_diff_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<DiffMode>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::prestate_tracer(PreStateConfig {
             diff_mode: Some(true),
             disable_code: Some(true),
@@ -110,8 +175,9 @@ where
         }),
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
     match provider
-        .debug_trace_call(tx_request.into(), block, options)
+        .debug_trace_call(tx_request, block, options)
         .await
         .map_err(|e| anyhow!("prestate debug_trace_call failed: {}", e))?
     {
@@ -133,15 +199,33 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
-    let options = GethDebugTracingCallOptions {
+    get_call_frame_from_call_with_profile(provider, tx_request, block, SimProfile::Chain).await
+}
+
+/// [`get_call_frame_from_call`] with an explicit [`SimProfile`] controlling
+/// the simulated environment (gas limits). `SimProfile::Chain` is identical to
+/// the plain function.
+pub async fn get_call_frame_from_call_with_profile<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+) -> Result<CallFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
+    let mut tx_request = tx_request.into();
+    let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::call_tracer(CallConfig {
             with_log: Some(true),
             ..Default::default()
         }),
         ..Default::default()
     };
+    apply_sim_profile(&mut tx_request, &mut options, profile);
     match provider
-        .debug_trace_call(tx_request.into(), block, options)
+        .debug_trace_call(tx_request, block, options)
         .await
         .map_err(|e| anyhow!("callTracer debug_trace_call failed: {}", e))?
     {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -18,9 +18,10 @@ use alloy_provider::ext::DebugApi;
 use alloy_rpc_types::TransactionTrait;
 use anyhow::{Result, anyhow, bail};
 
-use gas_analyzer_core::SimProfile;
+use alloy::rpc::types::state::{AccountOverride, StateOverridesBuilder};
 use gas_analyzer_core::trace::compute_state_updates;
 use gas_analyzer_core::types::{Opcode, StateUpdate};
+use gas_analyzer_core::{OverlayEnv, SimProfile};
 use gas_analyzer_estimator::PrecedingTx;
 
 /// Apply a [`SimProfile`]'s environment overrides to a `debug_traceCall`
@@ -49,6 +50,27 @@ fn apply_sim_profile(
             .block_overrides
             .get_or_insert_with(BlockOverrides::default)
             .gas_limit = Some(block_gas);
+    }
+}
+
+/// Mount a pinned [`OverlayEnv`]'s code bindings as `debug_traceCall` state
+/// overrides. To the simulated EVM an overlaid chunk is indistinguishable
+/// from a deployed data contract; to consensus the overlay is part of the
+/// versioned env (see `gas_analyzer_core::overlay::env_commitment`), so it is
+/// applied unconditionally, like the gas overrides. Callers must have
+/// verified the env against the pinned manifest (`OverlayEnv::verify`).
+fn apply_overlay_env(options: &mut GethDebugTracingCallOptions, env: &OverlayEnv) {
+    let mut builder = StateOverridesBuilder::default();
+    for overlay in &env.overlays {
+        builder = builder.append(
+            overlay.address,
+            AccountOverride::default().with_code(overlay.code.clone()),
+        );
+    }
+    let overrides = builder.build();
+    match &mut options.state_overrides {
+        Some(existing) => existing.extend(overrides),
+        none => *none = Some(overrides),
     }
 }
 
@@ -111,6 +133,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
+    get_trace_from_call_with_env(provider, tx_request, block, profile, None).await
+}
+
+/// [`get_trace_from_call_with_profile`] additionally mounting a pinned [`OverlayEnv`]'s
+/// code bindings as state overrides (`None` is identical to the plain
+/// profile function). The env must already be verified against the pinned
+/// manifest.
+pub async fn get_trace_from_call_with_env<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
+) -> Result<DefaultFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
     let mut tx_request = tx_request.into();
     let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions {
@@ -124,6 +164,9 @@ where
         ..Default::default()
     };
     apply_sim_profile(&mut tx_request, &mut options, profile);
+    if let Some(env) = overlay {
+        apply_overlay_env(&mut options, env);
+    }
 
     let GethTrace::Default(trace) = provider
         .debug_trace_call(tx_request, block, options)
@@ -166,6 +209,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
+    get_prestate_diff_from_call_with_env(provider, tx_request, block, profile, None).await
+}
+
+/// [`get_prestate_diff_from_call_with_profile`] additionally mounting a pinned [`OverlayEnv`]'s
+/// code bindings as state overrides (`None` is identical to the plain
+/// profile function). The env must already be verified against the pinned
+/// manifest.
+pub async fn get_prestate_diff_from_call_with_env<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
+) -> Result<DiffMode>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
     let mut tx_request = tx_request.into();
     let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::prestate_tracer(PreStateConfig {
@@ -176,6 +237,9 @@ where
         ..Default::default()
     };
     apply_sim_profile(&mut tx_request, &mut options, profile);
+    if let Some(env) = overlay {
+        apply_overlay_env(&mut options, env);
+    }
     match provider
         .debug_trace_call(tx_request, block, options)
         .await
@@ -215,6 +279,24 @@ where
     P: Provider + DebugApi,
     Req: Into<alloy::rpc::types::eth::TransactionRequest>,
 {
+    get_call_frame_from_call_with_env(provider, tx_request, block, profile, None).await
+}
+
+/// [`get_call_frame_from_call_with_profile`] additionally mounting a pinned [`OverlayEnv`]'s
+/// code bindings as state overrides (`None` is identical to the plain
+/// profile function). The env must already be verified against the pinned
+/// manifest.
+pub async fn get_call_frame_from_call_with_env<P, Req>(
+    provider: &P,
+    tx_request: Req,
+    block: BlockId,
+    profile: SimProfile,
+    overlay: Option<&OverlayEnv>,
+) -> Result<CallFrame>
+where
+    P: Provider + DebugApi,
+    Req: Into<alloy::rpc::types::eth::TransactionRequest>,
+{
     let mut tx_request = tx_request.into();
     let mut options = GethDebugTracingCallOptions {
         tracing_options: GethDebugTracingOptions::call_tracer(CallConfig {
@@ -224,6 +306,9 @@ where
         ..Default::default()
     };
     apply_sim_profile(&mut tx_request, &mut options, profile);
+    if let Some(env) = overlay {
+        apply_overlay_env(&mut options, env);
+    }
     match provider
         .debug_trace_call(tx_request, block, options)
         .await

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -111,22 +111,48 @@ boundary. Hence:
   alongside the chain-config hash so a proof under the wrong profile cannot
   satisfy the verifier.
 
-### Required guest change (before slashing ships)
+### Fork support (implemented)
 
-`sp1-cc`'s `ClientExecutor` today builds its `BlockEnv`/`TxEnv` from the
-anchored header. For tracked functions executed under `UnboundedV1`, the guest
-must override, exactly:
+The BreadchainCoop `sp1-contract-call` fork (branch
+`ron/unbounded-env-overrides`, targeting `cancun-v1`) provides the mechanism:
 
 ```rust
-// inside the guest, after building the env from EvmSketchInput:
-block_env.gas_limit = gas_analyzer_core::UNBOUNDED_V1_BLOCK_GAS_LIMIT;
-tx_env.gas_limit    = gas_analyzer_core::UNBOUNDED_V1_TX_GAS_LIMIT;
-// and do NOT apply the EIP-7825 tx cap for this profile
+use sp1_cc_client_executor::EnvOverrides;
+use gas_analyzer_core::UNBOUNDED_V1_BLOCK_GAS_LIMIT;
+
+let overrides = EnvOverrides::gas_limits(UNBOUNDED_V1_BLOCK_GAS_LIMIT);
+
+// Host: prefetch state under the SAME limits the guest will execute with —
+// a host that OOGs early produces a witness the guest cannot complete on.
+let out = sketch.call_raw_with_overrides(&input, overrides).await?;
+let sketch_input = sketch.finalize().await?;
+
+// Guest: re-execute under the identical env; the overrides are bound into
+// `chainConfigHash` (ChainConfigWithEnvOverrides), so a proof under
+// different limits cannot satisfy the verifier.
+let executor = ClientExecutor::eth(&sketch_input)?;
+executor.execute_and_commit_with_overrides(input, overrides);
 ```
 
-This belongs in the BreadchainCoop `sp1-contract-call` fork (branch
-`cancun-v1`) as a profile-aware executor entry point, keyed by the same
-`SimProfile` the host used.
+Setting `tx_gas_limit` also lifts revm's EIP-7825 cap (2^24, Osaka+) to the
+same value, so execution is identical on both sides of the hardfork boundary.
+Regression tests in the fork pin the two invariants: a ~40M-gas call OOGs at
+exactly the header limit without overrides, and succeeds (burning more than
+any real block) under `gas_limits(1 << 40)`.
+
+> **Latent bug fixed along the way:** upstream sp1-cc assigned the gas limit
+> via `modify_tx_chained` on the context, but `Evm::transact` replaces the tx
+> env with the converted `ContractInput` — whose `TxEnv::default()` carries
+> revm's 2^24 builder default. Every sketch/guest execution was silently
+> capped at **16,777,216 gas** regardless of the header. Any tracked function
+> above ~16.7M gas would have OOG'd in host prefetch and guest re-execution
+> even in "bounded" mode.
+
+Remaining before slashing ships: merge the fork branch into `cancun-v1`, and
+have the slashing guest program (per `SP1_REVM_IMPLEMENTATION_SPEC.md`) pass
+`EnvOverrides::gas_limits(UNBOUNDED_V1_BLOCK_GAS_LIMIT)` — importing the
+constant from `gas-analyzer-core`, never restating it — and commit the profile
+version in its public values.
 
 ## What this mode does *not* change
 

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -1,0 +1,156 @@
+# Unbounded Simulation Mode (`SimProfile::UnboundedV1`)
+
+**Status:** Implemented (analyzer side) — guest-side mirroring required before slashing ships
+**Related:** [GAS_KILLER_SLASHING_SPEC.md](./GAS_KILLER_SLASHING_SPEC.md), [SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md), solidity-sdk PRs [#51](https://github.com/gas-killer/solidity-sdk/pull/51) (single-slot commitment), [#47](https://github.com/gas-killer/solidity-sdk/pull/47)/[#48](https://github.com/gas-killer/solidity-sdk/pull/48) (multi-call forwarding)
+
+## What it is
+
+Gas Killer's core trade is: **computation happens off-chain, only the net state
+diff lands on-chain.** Until now the analyzer simulated tracked functions under
+the real chain's environment, so a tracked function was still bounded by the
+block gas limit (and post-Osaka, the EIP-7825 2^24 tx cap) — even though nothing
+about the *payload* required that bound.
+
+`SimProfile::UnboundedV1` removes the bound. The tracked function is simulated
+under pinned, protocol-versioned limits ~24,000× a mainnet block:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `UNBOUNDED_V1_BLOCK_GAS_LIMIT` | `1 << 40` (~1.1 Tgas) | block env gas limit during simulation |
+| `UNBOUNDED_V1_TX_GAS_LIMIT` | `1 << 40` | tx gas limit during simulation (EIP-7825 cap deliberately not applied) |
+
+In exchange, the extracted payload must pass the **single-slot shape gate**
+(`validate_unbounded_shape`):
+
+- at most **one `Store`** — the consumer's commitment slot;
+- **no `CREATE`/`CREATE2`** — initcode replays on-chain at real gas;
+- any number of `Call` / `Log*` ops — but `Call`s re-execute on-chain at real
+  gas prices, so compute inside them is *not* killed. Multi-call forwarding
+  (`applyForwardedUpdates`, one commitment write per sibling contract) rides in
+  this category.
+
+The result: **unbounded Solidity, O(1) on-chain state.** A tracked function may
+iterate a million-entry order book, verify a multi-megabyte witness against a
+commitment, or run a whole matching epoch — what ships to `verifyAndUpdate` is
+one SSTORE, some logs, and bounded calls. The intended consumer shape is the
+single-slot commitment pattern of solidity-sdk PR #51, where the expanded state
+travels as a calldata witness and only its hash lives in storage.
+
+### Calldata
+
+Neither revm nor the EVM protocol caps calldata *size*; calldata is priced in
+gas (EIP-7623 floor). Lifting the gas limits therefore lifts the effective
+calldata bound too — `1 << 40` gas admits ~27 GB of floor-priced calldata.
+Multi-megabyte witnesses simulate fine even though they could never land in a
+real transaction; only the signed payload must fit on-chain.
+
+## How to use it
+
+```rust
+use gas_analyzer_core::SimProfile;
+use gas_analyzer_evmsketch::{
+    EvmSketchExecutorCache, call_to_encoded_state_updates_with_evmsketch_profiled,
+};
+
+let (payload, gas, is_heuristic, skipped) =
+    call_to_encoded_state_updates_with_evmsketch_profiled(
+        &cache, rpc_url, tx_request, block_number, SimProfile::UnboundedV1,
+    ).await?;
+```
+
+Semantics under `UnboundedV1`:
+
+1. Both extraction paths (prestate fast path *and* struct-log fallback) run the
+   `debug_traceCall` with `tx.gas = 2^40` and `blockOverrides.gasLimit = 2^40`.
+   The caller's `gas` field is overridden unconditionally — the profile is a
+   pinned protocol environment, not a hint.
+2. The extracted updates are validated against the shape gate; a violation is a
+   **hard error** (a consumer writing N slots scales on-chain like a plain
+   contract and defeats the mode).
+3. The **gas estimate still uses the real chain env** — `verifyAndUpdate` lands
+   in a real block, so applying the payload is priced under real limits.
+
+### Node requirement
+
+The node serving `debug_traceCall` has the last word on simulation gas:
+
+| Node | Requirement |
+|---|---|
+| anvil | `--disable-block-gas-limit` |
+| geth | `--rpc.gascap=0` (or ≥ the profile limit) |
+| reth | `--rpc.gascap` raised accordingly |
+
+A clamping node makes heavy calls OOG inside the tracer. This fails safe: the
+reverted root frame forces the struct-log fallback classification (PR #165), so
+a clamped simulation can produce an error — never an unsound diff.
+
+## Determinism: why the constants are versioned
+
+The environment override is **part of the protocol**, not a local tunable.
+Three parties re-execute the same tracked function and must get bit-identical
+results:
+
+1. **Operators**, when extracting the update payload they BLS/ECDSA-sign.
+2. **This analyzer**, when simulating on a user's behalf.
+3. **The SP1 slashing guest** ([SP1_REVM_IMPLEMENTATION_SPEC.md](./SP1_REVM_IMPLEMENTATION_SPEC.md)),
+   when a slasher re-executes the original function inside the zkVM to prove
+   the signed updates wrong.
+
+If the guest ran with the real header's gas limit while operators simulated
+under lifted limits, a heavy-but-honest execution would OOG in the guest,
+produce a different update set, and **falsely slash honest operators**.
+Conversely, ad-hoc per-operator limits would fragment quorum signatures at the
+boundary. Hence:
+
+- The limits are `pub const` in `gas_analyzer_core::sim_profile` — the guest
+  crate must import them from there (the crate is pure/WASM-safe and compiles
+  in a zkVM guest).
+- Any change to the values is a **new profile version** (`UnboundedV2`, …),
+  coordinated across operators and the committed guest ELF — never a silent
+  edit. The guest's public values should commit to the profile version
+  alongside the chain-config hash so a proof under the wrong profile cannot
+  satisfy the verifier.
+
+### Required guest change (before slashing ships)
+
+`sp1-cc`'s `ClientExecutor` today builds its `BlockEnv`/`TxEnv` from the
+anchored header. For tracked functions executed under `UnboundedV1`, the guest
+must override, exactly:
+
+```rust
+// inside the guest, after building the env from EvmSketchInput:
+block_env.gas_limit = gas_analyzer_core::UNBOUNDED_V1_BLOCK_GAS_LIMIT;
+tx_env.gas_limit    = gas_analyzer_core::UNBOUNDED_V1_TX_GAS_LIMIT;
+// and do NOT apply the EIP-7825 tx cap for this profile
+```
+
+This belongs in the BreadchainCoop `sp1-contract-call` fork (branch
+`cancun-v1`) as a profile-aware executor entry point, keyed by the same
+`SimProfile` the host used.
+
+## What this mode does *not* change
+
+- **Trust model.** The quorum still signs the diff; the proof (when it ships)
+  is a fraud proof, not a validity proof. Unbounded mode widens what operators
+  can compute, not what users must trust.
+- **On-chain application costs.** One commitment SSTORE (~5–22k gas) + BLS/ECDSA
+  verification overhead per `verifyAndUpdate`, regardless of off-chain compute.
+- **`Call` op costs.** Calls in the payload re-execute on-chain at real gas.
+  A forwarded multi-call bundle costs one commitment write per sibling contract
+  plus call overhead — still O(contracts), not O(compute).
+- **The serialization model.** One transition per `transitionIndex` per
+  consumer; a direct on-chain call to a tracked function still invalidates
+  in-flight signed updates. Heavy simulations widen this race window
+  (extraction + signing + proving all take longer than a cheap call) —
+  consumers using unbounded mode should gate direct execution paths.
+
+## Test coverage
+
+- `gas_analyzer_core::sim_profile` unit tests: profile overrides, shape gate
+  (single store / multi store / CREATE rejection / empty payload).
+- `gas-analyzer-evmsketch` anvil-backed integration tests
+  (`test_unbounded_profile_*`): a ~40M-gas busy-loop consumer OOGs under
+  `Chain` (classified `Fallback`, per #165's revert soundness rule) and
+  extracts exactly `[Store, Log1]` under `UnboundedV1` against a real anvil
+  with `--disable-block-gas-limit`; a two-slot writer extracts but fails the
+  shape gate with `TooManyStores { count: 2 }`.

--- a/docs/UNBOUNDED_MODE.md
+++ b/docs/UNBOUNDED_MODE.md
@@ -18,6 +18,24 @@ under pinned, protocol-versioned limits ~24,000× a mainnet block:
 |---|---|---|
 | `UNBOUNDED_V1_BLOCK_GAS_LIMIT` | `1 << 40` (~1.1 Tgas) | block env gas limit during simulation |
 | `UNBOUNDED_V1_TX_GAS_LIMIT` | `1 << 40` | tx gas limit during simulation (EIP-7825 cap deliberately not applied) |
+| `UNBOUNDED_V1_XL_BLOCK_GAS_LIMIT` | `1 << 43` (~8.8 Tgas) | block env gas limit under the `UnboundedV1Xl` tier |
+| `UNBOUNDED_V1_XL_TX_GAS_LIMIT` | `1 << 43` | tx gas limit under the `UnboundedV1Xl` tier |
+
+### The XL gas tier (`SimProfile::UnboundedV1Xl`)
+
+`UnboundedV1Xl` is a **raised gas tier of the same V1 profile family**:
+identical semantics and shape gate, only the pinned ceiling differs (2^43
+instead of 2^40). It exists for multi-Tgas tasks that blow through the V1 cap
+— the motivating consumer is Qwen3.5-35B-A3B on-chain inference at ~3.6 Tgas
+per call, which 2^43 admits with ~2.4× headroom. The tier is a versioned
+protocol constant selected per consumer, with the same determinism bargain as
+V1: operators, this analyzer, and the SP1 slashing guest must agree on it or
+their update sets diverge on the OOG boundary. Naming note: this is *not*
+"`UNBOUNDED_V2`" — that name belongs to the orthogonal pinned code-*overlay*
+env axis ([UNBOUNDED_OVERLAYS.md](./UNBOUNDED_OVERLAYS.md)). Either gas tier
+composes with overlays, and `env_commitment` already distinguishes tiers
+through the gas-limit values it binds, so no new commitment domain exists for
+XL.
 
 In exchange, the extracted payload must pass the **single-slot shape gate**
 (`validate_unbounded_shape`):
@@ -105,11 +123,12 @@ boundary. Hence:
 - The limits are `pub const` in `gas_analyzer_core::sim_profile` — the guest
   crate must import them from there (the crate is pure/WASM-safe and compiles
   in a zkVM guest).
-- Any change to the values is a **new profile version** (`UnboundedV2`, …),
-  coordinated across operators and the committed guest ELF — never a silent
-  edit. The guest's public values should commit to the profile version
-  alongside the chain-config hash so a proof under the wrong profile cannot
-  satisfy the verifier.
+- Any change to the values is a **new profile version** (`UnboundedV1Xl` is
+  the first such tier; note `UNBOUNDED_V2` names the overlay env axis, not a
+  gas tier), coordinated across operators and the committed guest ELF — never
+  a silent edit. The guest's public values should commit to the profile
+  version alongside the chain-config hash so a proof under the wrong profile
+  cannot satisfy the verifier.
 
 ### Fork support (implemented)
 
@@ -175,8 +194,9 @@ version in its public values.
 - `gas_analyzer_core::sim_profile` unit tests: profile overrides, shape gate
   (single store / multi store / CREATE rejection / empty payload).
 - `gas-analyzer-evmsketch` anvil-backed integration tests
-  (`test_unbounded_profile_*`): a ~40M-gas busy-loop consumer OOGs under
-  `Chain` (classified `Fallback`, per #165's revert soundness rule) and
-  extracts exactly `[Store, Log1]` under `UnboundedV1` against a real anvil
+  (`test_unbounded_profile_*`, `test_unbounded_xl_profile_*`): a ~40M-gas
+  busy-loop consumer OOGs under `Chain` (classified `Fallback`, per #165's
+  revert soundness rule) and extracts exactly `[Store, Log1]` under
+  `UnboundedV1` — and identically under `UnboundedV1Xl` — against a real anvil
   with `--disable-block-gas-limit`; a two-slot writer extracts but fails the
   shape gate with `TooManyStores { count: 2 }`.

--- a/docs/UNBOUNDED_OVERLAYS.md
+++ b/docs/UNBOUNDED_OVERLAYS.md
@@ -1,0 +1,64 @@
+# Pinned code overlays (`UNBOUNDED_V2`)
+
+Extension of the unbounded simulation profile ([UNBOUNDED_MODE.md](./UNBOUNDED_MODE.md))
+that mounts large immutable byte blobs — model weights, lookup tables, any read-only
+data — as contract **code in the simulation environment**, without the blobs ever being
+deployed on-chain.
+
+Motivating consumer: the on-chain LLM in gas-killer/solidity-sdk
+(`src/examples/onchain-llm/`). Qwen3-0.6B needs 597MB of int8 weights: ~24.3k data
+contracts and ~130B gas to deploy (~$0.4–4.5M on mainnet) — or, with overlays, **one
+32-byte hash** in the consumer's immutables.
+
+## Mechanism
+
+- **Manifest.** `manifestHash = keccak256(keccak256(weightsBlob) || keccak256(tokenizerBlob))`
+  (`overlay_manifest_hash`). This is the consumer's entire on-chain commitment.
+- **Chunking.** Blobs split into 24,575-byte chunks (`OVERLAY_CHUNK_PAYLOAD` = EIP-170
+  minus the STOP prefix), globally indexed: weight chunks first, then tokenizer chunks.
+  Each chunk mounts as runtime code `0x00 || payload` — byte-identical to the
+  SSTORE2-style data contracts of directory mode, so consumer read offsets don't change.
+- **Derived addresses.** Chunk `i` lives at
+  `address(keccak256("gaskiller.llm.overlay.v1" || manifestHash || u64_be(i)))[12..]`
+  (`overlay_chunk_address`, mirroring `Qwen3Engine.overlayChunkAddress` in solidity-sdk;
+  cross-pinned by test vectors in `core/src/overlay.rs`). No on-chain directory needed.
+- **Mounting.** [`OverlayEnv::from_blobs`] chunks, derives, and hashes;
+  [`OverlayEnv::verify`] refuses bytes that don't reproduce the pinned manifest. The
+  `*_with_env` RPC helpers and
+  `call_to_encoded_state_updates_with_evmsketch_env` thread the bindings into
+  `debug_traceCall` as `stateOverrides` `{address: {code}}` alongside the V1 gas
+  overrides. To EVM execution an overlaid chunk is indistinguishable from deployed code
+  (`EXTCODESIZE`/`EXTCODECOPY` identical).
+
+## Determinism and slashing (read this twice)
+
+Same bargain as V1's gas constants, extended: the overlay set is part of the
+**versioned pinned environment**. [`env_commitment`] hashes
+`domain || block_gas || tx_gas || manifest || n || (address, codeHash)*` — the V2
+domain when overlays are present, V1 otherwise. **This commitment must be bound into
+the SP1 slashing guest's `chainConfigHash`** (companion guest change, exactly like the
+V1 env overrides): a fraud proof simulated under different or missing overlay bytes
+then cannot verify, and honest operators using the pinned bytes cannot be falsely
+slashed. Until the guest binding ships, overlay mode must not be used for slashable
+quorums.
+
+Notes:
+
+- The shape gate is unchanged. Overlaid chunks are STOP-prefixed pure data: they cannot
+  execute, cannot SSTORE, and payload `Store`s always target the consumer's own storage,
+  so no additional gate rule is required.
+- Payload gas estimation stays on the real chain env (unchanged from V1): overlaid code
+  is only read during simulation and never appears in the payload.
+- Operators fetch blobs out-of-band (HuggingFace/IPFS/mirrors) **once**; availability is
+  a liveness concern, never a safety one — bytes are verified against the manifest
+  before mounting.
+
+## Operator lifecycle
+
+1. Fetch `weights.bin` + `tokenizer.bin` for the consumer's pinned manifest.
+2. `OverlayEnv::from_blobs(...)` then `env.verify(pinned_manifest)` — hard-refuse on
+   mismatch.
+3. Serve tracked calls via `call_to_encoded_state_updates_with_evmsketch_env(...,
+   SimProfile::UnboundedV1, Some(&env))`.
+4. Sanity check inside the mounted env: the consumer engine's
+   `checkArtifacts(address(0), manifestHash, packedConfig)` view must pass.


### PR DESCRIPTION
Stacked on #166 (merge that first; this diff is only the overlay commits).

## What

Extends the pinned unbounded env from `{gas limits}` to `{gas limits, address → code}`: large immutable blobs (LLM weights, lookup tables) mount as contract code in the simulation environment, verified against a single 32-byte manifest hash the consumer commits on-chain — no deployment, no on-chain directory.

Concretely, for the motivating consumer (solidity-sdk `onchain-llm`, Qwen3-0.6B): 597MB of weights = ~24.3k data contracts and ~130B gas to deploy in directory mode, vs **one immutable hash** in overlay mode. Measured end-to-end on anvil with the overlay mounted via setCode: 16-id chat prompt + 8-token answer ("Ethereum is a decentralized blockchain platform", bit-exact vs the integer reference) = **545.1B simulated gas** → one `Store` + logs on-chain.

## How

- **core/overlay.rs**: `CodeOverlay`, `OverlayEnv::from_blobs/verify` (chunk 24,575B → `0x00||payload`, derive addresses, hash; refuse manifest mismatches), `overlay_manifest_hash`, `overlay_chunk_address` (mirrors `Qwen3Engine.overlayChunkAddress`, cross-pinned by test vectors verified against the deployed Solidity via `cast call`), and `env_commitment` — the versioned pinned-env value (V1/V2 domain-separated) that **the SP1 guest must bind into `chainConfigHash`** (companion guest change, same pattern as #166's env overrides; overlay mode must not serve slashable quorums until that lands).
- **rpc**: `*_with_env` variants of the three `debug_traceCall` helpers mount the bindings as `stateOverrides {address: {code}}` alongside the V1 gas overrides; `*_with_profile` delegate with `None` (no API breaks).
- **evmsketch**: `call_to_encoded_state_updates_with_evmsketch_env` threads `Option<&OverlayEnv>` through the hybrid prestate/struct-log extraction; profiled/plain entrypoints unchanged.
- **Shape gate unchanged**: overlaid chunks are STOP-prefixed pure data — they can't execute or be written to, and payload `Store`s only target consumer storage.
- Payload gas estimation stays on the real chain env, as in #166.
- `docs/UNBOUNDED_OVERLAYS.md`: mechanism, derivation formulas (bit-identical to the consumer side), operator lifecycle, availability-is-liveness-not-safety.

## Tests

- core: derivation vectors cross-pinned against solidity-sdk, chunking/prefixing, manifest-mismatch refusal, env-commitment version/content separation (36 core tests pass).
- rpc/evmsketch: compile-threaded; existing unit tests pass (22 evmsketch lib tests). The anvil-crate integration tests fail identically on the base branch (pre-existing env issue, untouched here).
- Companion consumer + E2E: gas-killer/solidity-sdk branch `RonTuretzky/onchain-solidity-llm` — `GasKillerChat` overlay mode, `test_OverlayModeMatchesDirectoryMode` (vm.etch-mounted overlay produces byte-identical generation to directory mode), `tools/deploy_anvil.py --overlay`.

## Review focus (honest guesses)

- `StateOverridesBuilder`/`AccountOverride::with_code` usage matches alloy 1.0.37 — please sanity-check against your preferred override-construction style.
- `env_commitment` layout (domain || gas limits || manifest || n || (addr, codeHash)*) is a proposal — happy to align it with whatever the SP1 guest branch wants to hash.
- Overlay bytes currently arrive as in-memory blobs (`from_blobs`); a file-backed artifact store with paths in operator config is deliberately left to the service-side wiring PR.