### PR TITLE
refactor: move indexer crates out of default members and split tests

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -18,10 +18,30 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy (default workspace)
-        run: cargo clippy --workspace --exclude gas-killer-wasm --exclude gas-analyzer-anvil --all-targets -- -D warnings
+        run: |
+          cargo clippy --workspace \
+            --exclude gas-killer-wasm \
+            --exclude gas-analyzer-anvil \
+            --exclude indexer-api \
+            --exclude indexer-rpc \
+            --exclude indexer-store \
+            --exclude indexer-resolver \
+            --exclude indexer-service \
+            --exclude indexer-web \
+            --all-targets -- -D warnings
 
       - name: cargo check (default workspace)
-        run: cargo check --workspace --exclude gas-killer-wasm --exclude gas-analyzer-anvil --all-targets
+        run: |
+          cargo check --workspace \
+            --exclude gas-killer-wasm \
+            --exclude gas-analyzer-anvil \
+            --exclude indexer-api \
+            --exclude indexer-rpc \
+            --exclude indexer-store \
+            --exclude indexer-resolver \
+            --exclude indexer-service \
+            --exclude indexer-web \
+            --all-targets
 
   test-native:
     runs-on: ubuntu-latest
@@ -74,3 +94,41 @@ jobs:
       - name: Run WASM RPC integration test (Node.js)
         if: env.RPC_URL != ''
         run: node crates/wasm/tests/rpc_wasm.mjs
+
+  test-indexer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo clippy (indexer crates)
+        run: |
+          cargo clippy \
+            -p indexer-api \
+            -p indexer-rpc \
+            -p indexer-store \
+            -p indexer-resolver \
+            -p indexer-service \
+            -p indexer-web \
+            --all-targets -- -D warnings
+
+      - name: cargo check (indexer crates)
+        run: |
+          cargo check \
+            -p indexer-api \
+            -p indexer-rpc \
+            -p indexer-store \
+            -p indexer-resolver \
+            -p indexer-service \
+            -p indexer-web \
+            --all-targets
+
+      - name: cargo test (indexer crates)
+        run: |
+          cargo test \
+            -p indexer-api \
+            -p indexer-rpc \
+            -p indexer-store \
+            -p indexer-resolver \
+            -p indexer-service \
+            -p indexer-web

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,6 @@ default-members = [
     "crates/rpc",
     "crates/evmsketch",
     "crates/cli",
-    "crates/indexer-api",
-    "crates/indexer-rpc",
-    "crates/indexer-store",
-    "crates/indexer-resolver",
-    "crates/indexer-service",
-    "crates/indexer-web",
 ]
 
 [profile.bench]


### PR DESCRIPTION
Without this change, anyone doing engine-only work now silently compiles and tests the entire indexer stack (`sqlx/postgres`, `redis`, `axum`, `askama`, `reqwest`, `tokio-full`, `bcrypt`, `mimalloc`) on every plain check/test, and that combined-invocation build also unifies features across shared deps (`tokio`, `alloy`, `serde`, `tracing`, etc.) between engine and indexer crates that wouldn't otherwise mix.

## Changes
1. Drop the six `indexer-*` entries from default-members. Restores bare `cargo build/check/test` to the pre-PR engine-only scope.
2. Split CI into a separate job for the indexer stack (mirroring how `wasm`/`anvil` already get their own lane) instead of folding it into `lint`'s `--workspace` sweep. For example, `--workspace --exclude gas-killer-wasm --exclude gas-analyzer-anvil --exclude indexer-api --exclude indexer-rpc --exclude indexer-store --exclude indexer-resolver --exclude indexer-service --exclude indexer-web` for the engine job, plus a new job targeting just those six with `-p`.