### PR TITLE
ci: lint every feature configuration with cargo-hack

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -31,6 +31,25 @@ jobs:
             --features gas-analyzer-evmsketch/anvil \
             --all-targets -- -D warnings
 
+      # A single clippy run only ever sees one feature configuration, so anything behind a
+      # `#[cfg(feature = ...)]` that is off in that run is never linted. `--each-feature` lints every
+      # feature of the crates that have them, in both directions, and picks up new features
+      # automatically instead of relying on someone remembering to enumerate them here.
+      #
+      # `--exclude-no-default-features` skips the all-features-off build of `gas-analyzer-cli`: with
+      # neither `evmsketch` nor `anvil` the binary has no analysis backend at all, so it is not a
+      # configuration anyone runs.
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+
+      - name: cargo clippy (feature matrix)
+        run: |
+          cargo hack clippy \
+            -p gas-analyzer-evmsketch \
+            -p gas-analyzer-cli \
+            --each-feature --exclude-no-default-features \
+            --all-targets -- -D warnings
+
       - name: cargo check (default workspace)
         run: |
           cargo check --workspace \

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -539,7 +539,7 @@ pub async fn gas_estimate_block(
     println!("got {} receipts for block {}", receipts.len(), block_number);
     let mut reports = Vec::new();
     for receipt in receipts {
-        println!("processing {}", &receipt.transaction_hash);
+        println!("processing {}", receipt.transaction_hash);
         reports.push(
             get_report(&provider, receipt.transaction_hash, &receipt, &gk)
                 .await

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "evmsketch")]
 use alloy::consensus::Transaction as _;
+#[cfg(feature = "evmsketch")]
 use alloy::sol_types::SolError;
 use alloy::{hex, providers::ProviderBuilder};
 use alloy_provider::Provider;
 use anyhow::Result;
 use colored::Colorize;
+#[cfg(feature = "evmsketch")]
 use gas_analyzer_core::RevertingContext;
 use std::env;
 use url::Url;
@@ -13,6 +16,7 @@ use url::Url;
 /// Looks for hex-encoded revert data in the error message (the format revm
 /// produces: "Gas estimation reverted (gas: N): 0x...") and attempts to
 /// ABI-decode it as a `RevertingContext`.
+#[cfg(feature = "evmsketch")]
 fn decode_reverting_context(e: &anyhow::Error) -> Option<RevertingContext> {
     let msg = format!("{e:?}");
     let hex_start = msg.rfind("0x")?;
@@ -127,17 +131,20 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
             let block_number = receipt
                 .block_number
                 .expect("couldn't retrieve block number");
+            #[cfg(feature = "evmsketch")]
             let tx_index = receipt
                 .transaction_index
                 .expect("couldn't retrieve transaction index");
             let gas_used = receipt.gas_used;
             let original_status = receipt.status();
+            #[cfg(feature = "evmsketch")]
             let tx_sender = receipt.from;
 
             // Fetch the original tx so we can mirror its `msg.value` during
             // simulation. Pass-through contracts (deposit-then-forward, intent
             // settlers, swap routers) lose ETH otherwise and value-bearing
             // CALL state updates halt with OutOfFunds.
+            #[cfg(feature = "evmsketch")]
             let tx = provider
                 .get_transaction_by_hash(bytes.into())
                 .await?
@@ -147,6 +154,7 @@ async fn execute_command(cli_args: CliArgs) -> Result<()> {
                         hex::encode(bytes)
                     )
                 })?;
+            #[cfg(feature = "evmsketch")]
             let tx_value = tx.value();
 
             #[cfg(feature = "anvil")]


### PR DESCRIPTION
## Problem

A single `cargo clippy` run only ever sees **one** feature configuration. Anything behind a
`#[cfg(feature = ...)]` that happens to be off in that run is never linted — so `-D warnings` is a
weaker gate than it looks.

The workspace has four such regions today, and three of them were unlinted:

| configuration | linted before this PR? |
|---|---|
| `gas-analyzer-evmsketch`, default | ✅ |
| `gas-analyzer-evmsketch` + `anvil` | ✅ (added in #165) |
| `gas-analyzer-evmsketch` *without* `anvil` | ❌ |
| `gas-analyzer-evmsketch` + `heap-profile` (6 gates in `benches/flamegraph.rs`) | ❌ |
| `gas-analyzer-cli` + `anvil`, no default features (2 gates in `main.rs`) | ❌ |

The last row is not hypothetical. That is the exact configuration CI already builds in
`cargo test (anvil)`, and it has been emitting **four warnings** into the job log for some time —
they just never failed anything, because that step has no `-D warnings`:

```
warning: unused variable: `tx_index`
warning: unused variable: `tx_sender`
warning: unused variable: `tx_value`
warning: function `decode_reverting_context` is never used
```

## Change

**`cargo hack clippy --each-feature`** over the two crates that declare features. It lints each
feature in both directions and picks up new features automatically, rather than depending on someone
remembering to enumerate them. Installed prebuilt via `taiki-e/install-action@cargo-hack`.

`--exclude-no-default-features` skips the all-features-off build of `gas-analyzer-cli`: with neither
`evmsketch` nor `anvil` the binary has no analysis backend at all, so it is not a configuration
anyone runs. Every other configuration passes.

**Fixed what it surfaced** in `crates/cli/src/main.rs`: `decode_reverting_context`, three `let`
bindings, and the three imports that fed them are all reachable only from the `evmsketch` path, so
they now carry `#[cfg(feature = "evmsketch")]` — matching the gate already on
`use alloy_eips::BlockNumberOrTag` a few lines below. No behaviour change in any configuration that
was already building.

## Verification

Each configuration `--each-feature` will run, checked locally with `-D warnings`:

| configuration | before | after |
|---|---|---|
| `cli` default | pass | pass |
| `cli --no-default-features --features anvil` | **4 warnings** | pass |
| `cli --no-default-features --features evmsketch` | pass | pass |
| `evmsketch` default | pass | pass |
| `evmsketch --features heap-profile` | pass | pass |
| `evmsketch --features anvil` | pass | pass |

## Cost

The `cli + anvil` configuration pulls `gas-analyzer-anvil` into the **lint** job, which currently
excludes it — about 3 minutes cold locally, amortised by `Swatinem/rust-cache` after the first run.
The `evmsketch` configurations are nearly free, since `anvil`/`heap-profile` are dependency-free
`[]` features and only that one crate recompiles.

## Note on #166

#166 replaces `evmsketch`'s `anvil` feature with `#[ignore]` on those tests, for the same reason this
PR exists: a feature that guards only test code buys nothing but a configuration clippy cannot see.
That removes one row from the matrix here. The two PRs touch different lines of the workflow and do
not conflict in either merge order.

## Side effect: `gas-analyzer-anvil` is now linted

`cargo clippy -p gas-analyzer-cli --all-features` builds `gas-analyzer-anvil` as a workspace path
dependency, and `RUSTC_WORKSPACE_WRAPPER` applies clippy to workspace members even when they are
built as dependencies. So that crate is now gated by `-D warnings` despite appearing in the
`--exclude` list of the older `cargo clippy (default workspace)` step.

That surfaced exactly one lint — `useless_borrows_in_formatting` in `crates/anvil/src/lib.rs:542` —
fixed here. Worth knowing rather than being surprised by later: `--exclude` on one step does not keep
a crate out of another step that pulls it in as a dependency.

## Toolchain note

CI runs clippy **1.97.0**; `useless_borrows_in_formatting` does not exist in 1.94, so that lint could
not be reproduced locally and was fixed from the CI output. Local `cargo clippy` is therefore not
authoritative for this workflow — new lints land with each stable release, and this job widens the
surface they apply to.
