### PR TITLE
build: pin the Rust toolchain so CI is reproducible

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Pins the toolchain used by CI and by contributors.
+#
+# Without this file every runner resolves `stable` afresh, so a Rust release can turn a branch red
+# without anyone having touched it — clippy gains lints with each release, and `-D warnings` promotes
+# every one of them to a build failure. It also lets a contributor's local `cargo clippy` disagree
+# with CI, which makes a green local run meaningless as a pre-push check.
+#
+# Bumping `channel` is therefore a deliberate, reviewable change: expect new lints to surface and fix
+# them in the same PR.
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,12 +1,3 @@
-# Pins the toolchain used by CI and by contributors.
-#
-# Without this file every runner resolves `stable` afresh, so a Rust release can turn a branch red
-# without anyone having touched it — clippy gains lints with each release, and `-D warnings` promotes
-# every one of them to a build failure. It also lets a contributor's local `cargo clippy` disagree
-# with CI, which makes a green local run meaningless as a pre-push check.
-#
-# Bumping `channel` is therefore a deliberate, reviewable change: expect new lints to surface and fix
-# them in the same PR.
 [toolchain]
 channel = "1.97.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Problem

There is no `rust-toolchain.toml`, so every CI runner resolves `stable` afresh at job time. Two
consequences:

1. **A Rust release can turn a green branch red without anyone touching it.** `-D warnings` promotes
   every new clippy lint to a build failure, and clippy gains lints in each release. The failure
   lands on whichever PR happens to run next, looking like that PR's fault.
2. **A local `cargo clippy` is not a valid pre-push check.** Whatever a contributor happens to have
   installed decides which lints they see.

That second point is not hypothetical — it bit this repo today. CI runs clippy **1.97.0**; a local
run on **1.94.0** reported clean on the same tree, because `useless_borrows_in_formatting`
(`crates/anvil/src/lib.rs`, surfaced in #179) does not exist in 1.94. The lint could not be
reproduced locally even after forcing a rebuild, and had to be read off the CI log.

## Change

Pin to `1.97.0` — the version CI is demonstrably passing on today, not the newest available
(`1.97.1`), so this is a **no-op for CI behaviour** and adds only determinism. `components` ensures
`clippy` and `rustfmt` come with the toolchain on a fresh machine.

No workflow changes needed: rustup honours `rust-toolchain.toml` for every cargo invocation inside
the repo, including the `dtolnay/rust-toolchain@stable` step in `wasm-publish.yml`, which now
resolves to the pinned version rather than drifting independently. The wasm job's explicit
`rustup target add wasm32-unknown-unknown` keeps working — it adds the target to the pinned
toolchain. The target is deliberately *not* listed in the file, so jobs that do not need it do not
install it.

## Verification

Ran the CI gate locally on 1.97.0 (the first time local verification in this repo has actually been
authoritative):

- `cargo fmt --all -- --check` — clean. Worth confirming explicitly, since rustfmt output can also
  change between releases; it did not here.
- `cargo clippy` (default workspace, `-D warnings`) — clean.
- `cargo test` — clean.

## Bumping it later

Treat a `channel` bump as its own PR and expect new lints. The two knobs if a bump is ever
inconvenient: pin to a specific version as done here, or move to `-W warnings` in CI and gate on a
separate explicit lint list. This PR takes the first, which keeps the strict gate.
